### PR TITLE
Add changlelogs to codec and macro crates

### DIFF
--- a/codec/CHANGELOG.md
+++ b/codec/CHANGELOG.md
@@ -1,0 +1,2 @@
+See [../common/CHANGELOG.md] for the changes made to the non-macro parts of the crate,
+and [../macro/CHANGELOG.md] for the changes made to the macro.

--- a/macro/CHANGELOG.md
+++ b/macro/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+This document contains all changes to the crate since 0.1.19


### PR DESCRIPTION
Adds a changelog to the macro crate, and a changelog to the codec that simply refers the reader to the changelogs of the sub-crates.