### PR TITLE
Add zalgofy proc-macro

### DIFF
--- a/codec/src/lib.rs
+++ b/codec/src/lib.rs
@@ -203,4 +203,10 @@ mod tests {
         assert!(zalgo_encode("\r").is_err());
         assert!(zalgo_encode("\0").is_err());
     }
+
+    #[test]
+    fn check_zalgofy() {
+        const ZS: &str = zalgofy!("Zalgo");
+        assert_eq!(zalgo_decode(ZS).unwrap(), "Zalgo");
+    }
 }

--- a/codec/src/lib.rs
+++ b/codec/src/lib.rs
@@ -94,7 +94,7 @@ pub use zalgo_codec_common::{
 };
 
 #[cfg(feature = "macro")]
-pub use zalgo_codec_macro::zalgo_embed;
+pub use zalgo_codec_macro::{zalgo_embed, zalgofy};
 
 #[cfg(test)]
 mod tests {

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -113,13 +113,13 @@ pub fn zalgo_embed(encoded: TokenStream) -> TokenStream {
 /// # use zalgo_codec_macro::zalgofy;
 /// use zalgo_codec_common::zalgo_decode;
 /// # use std::string::FromUtf8Error;
-/// 
+///
 /// // Embeds the string "E\u{33a}\u{341}\u{34c}\u{347}\u{34f}" into the binary.
 /// const ZS: &str = zalgofy!("Zalgo");
 /// assert_eq!(zalgo_decode(ZS)?, "Zalgo");
 /// # Ok::<(), FromUtf8Error>(())
 /// ```
-/// 
+///
 /// # Errors
 ///
 /// Gives a compile error if any character in the string is not either a printable ACII or newline character.


### PR DESCRIPTION
This adds a proc-macro that converts a string into a single grapheme cluster at compile time.