### PR TITLE
Improve docstrings of `reserve` and `reserve_exact`

### DIFF
--- a/common/src/zalgo_string.rs
+++ b/common/src/zalgo_string.rs
@@ -415,7 +415,7 @@ impl ZalgoString {
 
     /// Same as [`String::reserve_exact`], see it for more information.
     ///
-    /// Reserves the capacity for exactly `additional` bytes more than the current length.
+    /// Reserves capacity for exactly `additional` bytes more than the current length.
     /// Unlike [`reserve`](ZalgoString::reserve), this will not deliberately over-allocate to speculatively avoid frequent allocations.
     /// After calling `reserve_exact`, capacity will be greater than or equal to `self.len() + additional`.
     ///

--- a/common/src/zalgo_string.rs
+++ b/common/src/zalgo_string.rs
@@ -400,7 +400,7 @@ impl ZalgoString {
 
     /// Same as [`String::reserve`], see it for more information.
     ///
-    /// Reserves capacity for at least additional bytes more than the current length.
+    /// Reserves capacity for at least `additional` bytes more than the current length.
     /// The allocator may reserve more space to speculatively avoid frequent allocations.
     /// After calling reserve, capacity will be greater than or equal to `self.len() + additional`.  
     ///
@@ -415,7 +415,7 @@ impl ZalgoString {
 
     /// Same as [`String::reserve_exact`], see it for more information.
     ///
-    /// Reserves the minimum capacity for at least additional bytes more than the current length.
+    /// Reserves the capacity for exactly `additional` bytes more than the current length.
     /// Unlike [`reserve`](ZalgoString::reserve), this will not deliberately over-allocate to speculatively avoid frequent allocations.
     /// After calling `reserve_exact`, capacity will be greater than or equal to `self.len() + additional`.
     ///


### PR DESCRIPTION
Improve the flow and accuracy of the text