### PR TITLE
Implement the `Index` trait for `ZalgoString`

### DIFF
--- a/common/src/zalgo_string.rs
+++ b/common/src/zalgo_string.rs
@@ -5,6 +5,7 @@ use crate::{decode_byte_pair, fmt, zalgo_encode, Error};
 use core::{
     iter::{ExactSizeIterator, FusedIterator},
     ops::{Index, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive},
+    slice::SliceIndex,
 };
 
 #[cfg(not(feature = "std"))]
@@ -72,6 +73,25 @@ impl ZalgoString {
     #[must_use = "the method returns a reference and does not modify `self`"]
     pub fn as_str(&self) -> &str {
         &self.0
+    }
+
+    /// Returns a subslice of `self`.
+    ///
+    /// This is the non-panicking alternative to indexing the `ZalgoString`. Returns [`None`] whenever
+    /// the equivalent indexing operation would panic.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use zalgo_codec_common::{Error, ZalgoString};
+    /// let zs = ZalgoString::new("Zalgo")?;
+    /// assert_eq!(zs.get(0..1), Some("E"));
+    /// assert_eq!(zs.get(1..=2), Some("\u{33a}"));
+    /// # Ok::<(), Error>(())
+    /// ```
+    #[inline]
+    pub fn get<I: SliceIndex<str>>(&self, index: I) -> Option<&<I as SliceIndex<str>>::Output> {
+        self.0.get(index)
     }
 
     /// Returns an iterator over the encoded characters of the `ZalgoString`.

--- a/common/src/zalgo_string.rs
+++ b/common/src/zalgo_string.rs
@@ -2,7 +2,10 @@
 
 use crate::{decode_byte_pair, fmt, zalgo_encode, Error};
 
-use core::iter::{ExactSizeIterator, FusedIterator};
+use core::{
+    iter::{ExactSizeIterator, FusedIterator},
+    ops::{Index, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive},
+};
 
 #[cfg(not(feature = "std"))]
 use alloc::{borrow::Cow, string::String, vec::Vec};
@@ -630,6 +633,26 @@ impl fmt::Display for ZalgoString {
         write!(f, "{}", self.0)
     }
 }
+
+// region: impl index
+
+macro_rules! impl_index {
+    ($($range:ty),+) => {
+        $(
+            impl Index<$range> for ZalgoString {
+                type Output = str;
+                #[inline]
+                fn index(&self, index: $range) -> &Self::Output {
+                    &self.0[index]
+                }
+            }
+        )+
+    };
+}
+
+impl_index! {Range<usize>, RangeTo<usize>, RangeFrom<usize>, RangeInclusive<usize>, RangeToInclusive<usize>, RangeFull}
+
+// endregion: impl index
 
 #[cfg(test)]
 mod test {

--- a/common/src/zalgo_string.rs
+++ b/common/src/zalgo_string.rs
@@ -97,7 +97,10 @@ impl ZalgoString {
     /// # Ok::<(), Error>(())
     /// ```
     #[inline]
-    pub fn get<I: SliceIndex<str>>(&self, index: I) -> Option<&<I as SliceIndex<str>>::Output> {
+    pub fn get<I>(&self, index: I) -> Option<&<I as SliceIndex<str>>::Output>
+    where
+        I: SliceIndex<str>,
+    {
         self.0.get(index)
     }
 

--- a/common/src/zalgo_string.rs
+++ b/common/src/zalgo_string.rs
@@ -803,4 +803,21 @@ mod test {
         assert!(zs.get(0..2).is_none());
         assert!(zs.get(0..42).is_none());
     }
+
+    #[test]
+    fn test_indexing() {
+        let zs = ZalgoString::new("Zalgo").unwrap();
+        assert_eq!(&zs[0..3], "E\u{33a}");
+        assert_eq!(&zs[..3], "E\u{33a}");
+        assert_eq!(&zs[0..=2], "E\u{33a}");
+        assert_eq!(&zs[..=2], "E\u{33a}");
+        assert_eq!(zs[..], zs);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_index_panic() {
+        let zs = ZalgoString::new("Zalgo").unwrap();
+        let _a = &zs[0..2];
+    }
 }

--- a/common/src/zalgo_string.rs
+++ b/common/src/zalgo_string.rs
@@ -77,6 +77,8 @@ impl ZalgoString {
 
     /// Returns a subslice of `self`.
     ///
+    /// Same as [`str::get`].
+    ///
     /// This is the non-panicking alternative to indexing the `ZalgoString`. Returns [`None`] whenever
     /// the equivalent indexing operation would panic.
     ///
@@ -85,8 +87,13 @@ impl ZalgoString {
     /// ```
     /// # use zalgo_codec_common::{Error, ZalgoString};
     /// let zs = ZalgoString::new("Zalgo")?;
-    /// assert_eq!(zs.get(0..1), Some("E"));
-    /// assert_eq!(zs.get(1..=2), Some("\u{33a}"));
+    /// assert_eq!(zs.get(0..3), Some("E\u{33a}"));
+    ///
+    /// // indices not on UTF-8 sequence boundaries
+    /// assert!(zs.get(0..4).is_none());
+    ///
+    /// // out of bounds
+    /// assert!(zs.get(..42).is_none());
     /// # Ok::<(), Error>(())
     /// ```
     #[inline]
@@ -787,5 +794,13 @@ mod test {
         assert_eq!(zs.len(), 1);
         assert_eq!(zs.decoded_len(), 0);
         assert!(zs.into_decoded_string().is_empty());
+    }
+
+    #[test]
+    fn test_get() {
+        let zs = ZalgoString::new("Zalgo").unwrap();
+        assert_eq!(zs.get(0..3), Some("E\u{33a}"));
+        assert!(zs.get(0..2).is_none());
+        assert!(zs.get(0..42).is_none());
     }
 }


### PR DESCRIPTION
This PR adds a macro that implements the `Index` trait for `ZalgoString` for a given list of types. It also uses said macro to implement the trait for all the `Range` types.