### PR TITLE
Make `Error` store a character instead of a byte

### DIFF
--- a/common/CHANGELOG.md
+++ b/common/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 This document contains all changes to the crate since version 0.9.4.
 
+## 0.11.0
+
+### Breaking changes
+
+- The `Error::NotAscii` variant now stores the unencodable character instead of just the first byte of it.
+- Removed the `byte` function from `Error`.
+
+### Minor changes
+
+- Add `is_not_ascii` and `is_unencodable_ascii` variant checking functions to `Error`.
+- Add `char` function to `Error`.
+
 ## 0.10.4
 
 - Implement the `Index` trait for the different range types for `ZalgoString`.

--- a/common/src/error.rs
+++ b/common/src/error.rs
@@ -121,7 +121,8 @@ impl fmt::Display for Error {
             ),
             Self::NotAscii(char, line, column) => write!(
                 f,
-                "line {line} at column {column}: '{char}' is not an ASCII character"
+                "line {line} at column {column}: unicode character '{char}' (U+{:x}) is not an ASCII character",
+                u32::from(*char)
             ),
         }
     }

--- a/common/src/error.rs
+++ b/common/src/error.rs
@@ -121,7 +121,7 @@ impl fmt::Display for Error {
             ),
             Self::NotAscii(char, line, column) => write!(
                 f,
-                "line {line} at column {column}: unicode character '{char}' (U+{:x}) is not an ascii character",
+                "line {line} at column {column}: character '{char}' (U+{:x}) is not an ascii character",
                 u32::from(*char)
             ),
         }

--- a/common/src/error.rs
+++ b/common/src/error.rs
@@ -77,7 +77,7 @@ impl Error {
     }
 
     /// If the unencodable character is an ASCII character
-    /// this function returns a represenation of it.
+    /// this function returns a representation of it.
     ///
     /// # Examples
     ///

--- a/common/src/error.rs
+++ b/common/src/error.rs
@@ -55,7 +55,7 @@ impl Error {
         }
     }
 
-    /// Returns the value of the unencodable character.
+    /// Returns the unencodable character.
     ///
     /// # Examples
     ///

--- a/common/src/error.rs
+++ b/common/src/error.rs
@@ -95,14 +95,14 @@ impl Error {
         }
     }
 
-    /// Returns whether the error is the [NotAscii](Error::NotAscii) variant.
+    /// Returns whether the error is the [`NotAscii`](Error::NotAscii) variant.
     #[inline]
     #[must_use = "the method returns a new value and does not modify `self`"]
     pub const fn is_not_ascii(&self) -> bool {
         matches!(self, Self::NotAscii(_, _, _))
     }
 
-    /// Returns whether the error is the [UnencodableAscii](Error::UnencodableAscii) variant.
+    /// Returns whether the error is the [`UnencodableAscii`](Error::UnencodableAscii) variant.
     #[inline]
     #[must_use = "the method returns a new value and does not modify `self`"]
     pub const fn is_unencodable_ascii(&self) -> bool {

--- a/common/src/error.rs
+++ b/common/src/error.rs
@@ -131,7 +131,7 @@ impl fmt::Display for Error {
             ),
             Self::NotAscii(char, line, column) => write!(
                 f,
-                "line {line} at column {column}: character '{char}' (U+{:x}) is not an ascii character",
+                "line {line} at column {column}: character '{char}' (U+{:X}) is not an ascii character",
                 u32::from(*char)
             ),
         }

--- a/common/src/error.rs
+++ b/common/src/error.rs
@@ -63,7 +63,7 @@ impl Error {
     /// # use zalgo_codec_common::{Error, zalgo_encode};
     /// assert_eq!(zalgo_encode("CRLF\r\n").err().map(|e| e.char()), Some('\r'));
     ///
-    /// // Only the first unicode character is returned. E.g. some emojis consist of
+    /// // Only the first unicode character is returned. Some emojis consist of
     /// // many unicode characters:
     /// assert_eq!(zalgo_encode("❤️").err().map(|e| e.char()), Some('❤'));
     /// ```

--- a/common/src/error.rs
+++ b/common/src/error.rs
@@ -76,10 +76,8 @@ impl Error {
         }
     }
 
-    /// Return a representation of the unencodable byte.
-    /// This exists if the character is an unencodable ASCII character.
-    /// If it is some other unicode character we only know its first byte, so we can not
-    /// accurately represent it.
+    /// If the unencodable character is an ASCII character
+    /// this function returns a represenation of it.
     ///
     /// # Examples
     ///

--- a/common/src/error.rs
+++ b/common/src/error.rs
@@ -30,7 +30,7 @@ impl Error {
     /// assert_eq!(zalgo_encode("a\nb\nc\r\n").err().map(|e| e.line()), Some(3));
     /// ```
     #[inline]
-    #[must_use = "the method returns a new valus and does not modify `self`"]
+    #[must_use = "the method returns a new value and does not modify `self`"]
     pub const fn line(&self) -> usize {
         match self {
             Self::UnencodableAscii(_, line, _, _) | Self::NotAscii(_, line, _) => *line,
@@ -48,7 +48,7 @@ impl Error {
     /// assert_eq!(zalgo_encode("I\n❤️\n🎂").err().map(|e|e.column()), Some(1));
     /// ```
     #[inline]
-    #[must_use = "the method returns a new valus and does not modify `self`"]
+    #[must_use = "the method returns a new value and does not modify `self`"]
     pub const fn column(&self) -> usize {
         match self {
             Self::UnencodableAscii(_, _, column, _) | Self::NotAscii(_, _, column) => *column,

--- a/common/src/error.rs
+++ b/common/src/error.rs
@@ -26,8 +26,8 @@ impl Error {
     ///
     /// ```
     /// # use zalgo_codec_common::{Error, zalgo_encode};
-    /// assert_eq!(zalgo_encode("❤️").err().map(|e| e.line()), Some(1));
-    /// assert_eq!(zalgo_encode("a\nb\nc\r\n").err().map(|e| e.line()), Some(3));
+    /// assert_eq!(zalgo_encode("❤️").map_err(|e| e.line()), Err(1));
+    /// assert_eq!(zalgo_encode("a\nb\nc\r\n").map_err(|e| e.line()), Err(3));
     /// ```
     #[inline]
     #[must_use = "the method returns a new value and does not modify `self`"]
@@ -44,8 +44,8 @@ impl Error {
     ///
     /// ```
     /// # use zalgo_codec_common::{Error, zalgo_encode};
-    /// assert_eq!(zalgo_encode("I ❤️ 🎂").err().map(|e| e.column()), Some(3));
-    /// assert_eq!(zalgo_encode("I\n❤️\n🎂").err().map(|e|e.column()), Some(1));
+    /// assert_eq!(zalgo_encode("I ❤️ 🎂").map_err(|e| e.column()), Err(3));
+    /// assert_eq!(zalgo_encode("I\n❤️\n🎂").map_err(|e|e.column()), Err(1));
     /// ```
     #[inline]
     #[must_use = "the method returns a new value and does not modify `self`"]
@@ -61,11 +61,11 @@ impl Error {
     ///
     /// ```
     /// # use zalgo_codec_common::{Error, zalgo_encode};
-    /// assert_eq!(zalgo_encode("CRLF\r\n").err().map(|e| e.char()), Some('\r'));
+    /// assert_eq!(zalgo_encode("CRLF\r\n").map_err(|e| e.char()), Err('\r'));
     ///
     /// // Only the first unicode character is returned. Some emojis consist of
     /// // many unicode characters:
-    /// assert_eq!(zalgo_encode("❤️").err().map(|e| e.char()), Some('❤'));
+    /// assert_eq!(zalgo_encode("❤️").map_err(|e| e.char()), Err('❤'));
     /// ```
     #[inline]
     #[must_use = "the method returns a new value and does not modify `self`"]
@@ -85,8 +85,8 @@ impl Error {
     ///
     /// ```
     /// # use zalgo_codec_common::zalgo_encode;
-    /// assert_eq!(zalgo_encode("\r").err().map(|e| e.representation()).flatten(), Some("Carriage Return"));
-    /// assert_eq!(zalgo_encode("❤️").err().map(|e| e.representation()).flatten(), None);
+    /// assert_eq!(zalgo_encode("\r").map_err(|e| e.representation()), Err(Some("Carriage Return")));
+    /// assert_eq!(zalgo_encode("❤️").map_err(|e| e.representation()), Err(None));
     /// ```
     #[inline]
     #[must_use = "the method returns a new value and does not modify `self`"]

--- a/common/src/error.rs
+++ b/common/src/error.rs
@@ -153,11 +153,6 @@ mod test {
         assert_eq!(err.line(), 1);
         assert_eq!(err.column(), 7);
         assert_eq!(err.representation(), None);
-        assert_eq!(format!("{err:?}"), "NotAscii('å', 1, 7)");
-        assert_eq!(
-            format!("{err}"),
-            "line 1 at column 7: can not encode non-ascii character 'å' (U+E5)"
-        );
 
         let err2 = Error::UnencodableAscii(13, 1, 2, "Carriage Return");
         assert!(err2.is_unencodable_ascii());
@@ -165,14 +160,6 @@ mod test {
         assert_eq!(err2.line(), 1);
         assert_eq!(err2.column(), 2);
         assert_eq!(err2.representation(), Some("Carriage Return"));
-        assert_eq!(
-            format!("{err2:?}"),
-            "UnencodableAscii(13, 1, 2, \"Carriage Return\")"
-        );
-        assert_eq!(
-            format!("{err2}"),
-            "line 1 at column 2: can not encode ascii 'Carriage Return' character with byte value 13"
-        );
 
         assert_ne!(err, err2);
         let err3 = err;

--- a/common/src/error.rs
+++ b/common/src/error.rs
@@ -127,11 +127,11 @@ impl fmt::Display for Error {
         match self {
             Self::UnencodableAscii(byte, line, column, repr) => write!(
                 f,
-                "line {line} at column {column}: can not encode ascii \"{repr}\" character with byte value {byte}"
+                "line {line} at column {column}: can not encode ascii '{repr}' character with byte value {byte}"
             ),
             Self::NotAscii(char, line, column) => write!(
                 f,
-                "line {line} at column {column}: character '{char}' (U+{:X}) is not an ascii character",
+                "line {line} at column {column}: can not encode non-ascii character '{char}' (U+{:X})",
                 u32::from(*char)
             ),
         }
@@ -148,15 +148,25 @@ mod test {
     #[test]
     fn test_error() {
         let err = Error::NotAscii('å', 1, 7);
+        assert!(err.is_not_ascii());
         assert_eq!(err.char(), 'å');
         assert_eq!(err.line(), 1);
         assert_eq!(err.column(), 7);
         assert_eq!(err.representation(), None);
+        assert_eq!(
+            format!("{err}"),
+            "line 1 at column 7: can not encode non-ascii character 'å' (U+E5)"
+        );
 
         let err = Error::UnencodableAscii(13, 1, 2, "Carriage Return");
+        assert!(err.is_unencodable_ascii());
         assert_eq!(err.char(), '\r');
         assert_eq!(err.line(), 1);
         assert_eq!(err.column(), 2);
         assert_eq!(err.representation(), Some("Carriage Return"));
+        assert_eq!(
+            format!("{err}"),
+            "line 1 at column 2: can not encode ascii 'Carriage Return' character with byte value 13"
+        );
     }
 }

--- a/common/src/error.rs
+++ b/common/src/error.rs
@@ -57,16 +57,17 @@ impl Error {
 
     /// Returns the unencodable character that caused the error.
     ///
+    /// This may not match with what you see when you look at the unencoded string in a text editor since
+    /// some grapheme clusters consist of many unicode characters.
+    ///
     /// # Examples
     ///
     /// ```
     /// # use zalgo_codec_common::zalgo_encode;
     /// assert_eq!(zalgo_encode("CRLF\r\n").map_err(|e| e.char()), Err('\r'));
     ///
-    /// ```
-    /// This may not match with what you see when you look at the string in a text editor since
-    /// some grapheme clusters consist of many unicode characters:  
-    /// The ❤️ emoji consists of two codepoints, the heart `U+2764` and the color variant selector `U+FE0F`
+    /// ```  
+    /// The ❤️ emoji consists of two characters, the heart `U+2764` and the color variant selector `U+FE0F`
     /// Since the heart in not encodable, that is the place where the error is generated:
     /// ```
     /// # use zalgo_codec_common::zalgo_encode;

--- a/common/src/error.rs
+++ b/common/src/error.rs
@@ -170,5 +170,7 @@ mod test {
         );
 
         assert_ne!(err, err2);
+        let err3 = err;
+        assert_eq!(err, err3);
     }
 }

--- a/common/src/error.rs
+++ b/common/src/error.rs
@@ -55,17 +55,28 @@ impl Error {
         }
     }
 
-    /// Returns the unencodable character.
+    /// Returns the unencodable character that caused the error.
     ///
     /// # Examples
     ///
     /// ```
-    /// # use zalgo_codec_common::{Error, zalgo_encode};
+    /// # use zalgo_codec_common::zalgo_encode;
     /// assert_eq!(zalgo_encode("CRLF\r\n").map_err(|e| e.char()), Err('\r'));
     ///
-    /// // Only the first unicode character is returned. Some emojis consist of
-    /// // many unicode characters:
+    /// ```
+    /// This may not match with what you see when you look at the string in a text editor since
+    /// some grapheme clusters consist of many unicode characters:  
+    /// The ❤️ emoji consists of two codepoints, the heart `U+2764` and the color variant selector `U+FE0F`
+    /// Since the heart in not encodable, that is the place where the error is generated:
+    /// ```
+    /// # use zalgo_codec_common::zalgo_encode;
     /// assert_eq!(zalgo_encode("❤️").map_err(|e| e.char()), Err('❤'));
+    /// ```
+    /// The grapheme cluster `á` consists of a normal `a` and a combining acute accent, `U+301`.
+    /// The `a` can be encoded and the combining acute accent can not, so the error points only to the accent:
+    /// ```
+    /// # use zalgo_codec_common::zalgo_encode;
+    /// assert_eq!(zalgo_encode("á").map_err(|e| e.char()), Err('\u{301}'))
     /// ```
     #[inline]
     #[must_use = "the method returns a new value and does not modify `self`"]

--- a/common/src/error.rs
+++ b/common/src/error.rs
@@ -117,11 +117,11 @@ impl fmt::Display for Error {
         match self {
             Self::UnencodableAscii(byte, line, column, repr) => write!(
                 f,
-                "line {line} at column {column}: can not encode ASCII \"{repr}\" character with byte value {byte}"
+                "line {line} at column {column}: can not encode ascii \"{repr}\" character with byte value {byte}"
             ),
             Self::NotAscii(char, line, column) => write!(
                 f,
-                "line {line} at column {column}: unicode character '{char}' (U+{:x}) is not an ASCII character",
+                "line {line} at column {column}: unicode character '{char}' (U+{:x}) is not an ascii character",
                 u32::from(*char)
             ),
         }

--- a/common/src/error.rs
+++ b/common/src/error.rs
@@ -153,6 +153,7 @@ mod test {
         assert_eq!(err.line(), 1);
         assert_eq!(err.column(), 7);
         assert_eq!(err.representation(), None);
+        assert_eq!(format!("{err:?}"), "NotAscii('å', 1, 7)");
         assert_eq!(
             format!("{err}"),
             "line 1 at column 7: can not encode non-ascii character 'å' (U+E5)"
@@ -164,6 +165,10 @@ mod test {
         assert_eq!(err2.line(), 1);
         assert_eq!(err2.column(), 2);
         assert_eq!(err2.representation(), Some("Carriage Return"));
+        assert_eq!(
+            format!("{err2:?}"),
+            "UnencodableAscii(13, 1, 2, \"Carriage Return\")"
+        );
         assert_eq!(
             format!("{err2}"),
             "line 1 at column 2: can not encode ascii 'Carriage Return' character with byte value 13"

--- a/common/src/error.rs
+++ b/common/src/error.rs
@@ -158,15 +158,17 @@ mod test {
             "line 1 at column 7: can not encode non-ascii character 'å' (U+E5)"
         );
 
-        let err = Error::UnencodableAscii(13, 1, 2, "Carriage Return");
-        assert!(err.is_unencodable_ascii());
-        assert_eq!(err.char(), '\r');
-        assert_eq!(err.line(), 1);
-        assert_eq!(err.column(), 2);
-        assert_eq!(err.representation(), Some("Carriage Return"));
+        let err2 = Error::UnencodableAscii(13, 1, 2, "Carriage Return");
+        assert!(err2.is_unencodable_ascii());
+        assert_eq!(err2.char(), '\r');
+        assert_eq!(err2.line(), 1);
+        assert_eq!(err2.column(), 2);
+        assert_eq!(err2.representation(), Some("Carriage Return"));
         assert_eq!(
-            format!("{err}"),
+            format!("{err2}"),
             "line 1 at column 2: can not encode ascii 'Carriage Return' character with byte value 13"
         );
+
+        assert_ne!(err, err2);
     }
 }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -144,10 +144,10 @@ pub fn zalgo_encode(string: &str) -> Result<String, Error> {
     let mut result = Vec::with_capacity(2 * string.len() + 1);
     result.push(b'E');
 
-    for batch in string.as_bytes().chunks(BATCH_SIZE) {
+    for (i, batch) in string.as_bytes().chunks(BATCH_SIZE).enumerate() {
         let mut buffer = [0; 2 * BATCH_SIZE];
         let mut encoded = 0;
-        for byte in batch {
+        for (j, byte) in batch.iter().enumerate() {
             // Only encode ASCII bytes corresponding to printable characters or newlines.
             if (32..127).contains(byte) || *byte == b'\n' {
                 if *byte == b'\n' {
@@ -164,7 +164,10 @@ pub fn zalgo_encode(string: &str) -> Result<String, Error> {
             } else {
                 match nonprintable_char_repr(*byte) {
                     Some(repr) => return Err(Error::UnencodableAscii(*byte, line, column, repr)),
-                    None => return Err(Error::NotAscii(*byte, line, column)),
+                    None => {
+                        let char = string[i*BATCH_SIZE + j..].chars().next().expect("i + j is within the string, so string.chars().next() should find a char");
+                        return Err(Error::NotAscii(char, line, column));
+                    }
                 }
             }
         }
@@ -268,9 +271,7 @@ fn decode_byte_pair(odd: u8, even: u8) -> u8 {
 /// # use zalgo_codec_common::{Error, zalgo_wrap_python};
 /// assert_eq!(
 ///     zalgo_wrap_python(r#"print("That will be 5€ please")"#),
-///     // € is not an ASCII character, the first byte in its utf-8 representation is 226
-///     // and it is the 22nd character on the first line in the string.
-///     Err(Error::NotAscii(226, 1, 22))
+///     Err(Error::NotAscii('€', 1, 22))
 /// );
 /// ```
 #[must_use = "the function returns a new value and does not modify the input"]

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -170,7 +170,8 @@ pub fn zalgo_encode(string: &str) -> Result<String, Error> {
                         // character and that Strings in Rust are valid utf-8.
                         // All of this means that the value that starts at this index is a utf-8 encoded
                         // character, which `chars.next()` will extract.
-                        let char = string.split_at(i*BATCH_SIZE + j).1.chars().next().expect("i + j is within the string, so string.chars().next() should find a char");
+                        let char = string.split_at(i*BATCH_SIZE + j).1.chars().next()
+                            .expect("i + j is within the string and on a char boundary, so string.chars().next() should find a char");
                         return Err(Error::NotAscii(char, line, column));
                     }
                 }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -165,7 +165,7 @@ pub fn zalgo_encode(string: &str) -> Result<String, Error> {
                 match nonprintable_char_repr(*byte) {
                     Some(repr) => return Err(Error::UnencodableAscii(*byte, line, column, repr)),
                     None => {
-                        let char = string[i*BATCH_SIZE + j..].chars().next().expect("i + j is within the string, so string.chars().next() should find a char");
+                        let char = string.split_at(i*BATCH_SIZE + j).1.chars().next().expect("i + j is within the string, so string.chars().next() should find a char");
                         return Err(Error::NotAscii(char, line, column));
                     }
                 }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -166,8 +166,8 @@ pub fn zalgo_encode(string: &str) -> Result<String, Error> {
                     Some(repr) => return Err(Error::UnencodableAscii(*byte, line, column, repr)),
                     None => {
                         // The panic should never trigger since we know that string[i*BATCH_SIZE + j]
-                        // has some value and that this value is the first byte of a non-ascii
-                        // character and that Strings in Rust are valid utf-8.
+                        // has some value which is stored in `byte`, and that this value is the first
+                        // byte of a non-ascii character and that Strings in Rust are valid utf-8.
                         // All of this means that the value that starts at this index is a utf-8 encoded
                         // character, which `chars.next()` will extract.
                         let char = string.split_at(i*BATCH_SIZE + j).1.chars().next()

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -165,6 +165,11 @@ pub fn zalgo_encode(string: &str) -> Result<String, Error> {
                 match nonprintable_char_repr(*byte) {
                     Some(repr) => return Err(Error::UnencodableAscii(*byte, line, column, repr)),
                     None => {
+                        // The panic should never trigger since we know that string[i*BATCH_SIZE + j]
+                        // has some value and that this value is the first byte of a non-ascii
+                        // character and that Strings in Rust are valid utf-8.
+                        // All of this means that the value that starts at this index is a utf-8 encoded
+                        // character, which `chars.next()` will extract.
                         let char = string.split_at(i*BATCH_SIZE + j).1.chars().next().expect("i + j is within the string, so string.chars().next() should find a char");
                         return Err(Error::NotAscii(char, line, column));
                     }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -233,7 +233,7 @@ pub fn zalgo_decode(encoded: &str) -> Result<String, FromUtf8Error> {
 
 #[inline]
 #[must_use = "the function returns a new value and does not modify its inputs"]
-fn decode_byte_pair(odd: u8, even: u8) -> u8 {
+const fn decode_byte_pair(odd: u8, even: u8) -> u8 {
     ((odd << 6 & 64 | even & 63) + 22) % 133 + 10
 }
 

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -337,3 +337,14 @@ const fn nonprintable_char_repr(byte: u8) -> Option<&'static str> {
         None
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_char() {
+        assert_eq!(zalgo_encode("Zalgo\r").map_err(|e| e.char()), Err('\r'));
+        assert_eq!(zalgo_encode("Zålgo").map_err(|e| e.char()), Err('å'));
+    }
+}


### PR DESCRIPTION
This PR changes the `Error` type so that it can report the actual character that caused it instead of only the first byte.  
It introduces a call to `Option::expect`, but it should be impossible to cause the panic condition.