### PR TITLE
Add a `std::backtrace::Backtrace` to the `Error` type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4306,17 +4306,8 @@ dependencies = [
  "rand",
  "rfd",
  "unicode-segmentation",
- "zalgo-codec-common 0.11.1",
- "zalgo-codec-macro 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "zalgo-codec-common"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ac8c8f6951f6161e37b276e2429aebaab077f31d9f5e7de362afcd1c9b13219"
-dependencies = [
- "serde",
+ "zalgo-codec-common",
+ "zalgo-codec-macro",
 ]
 
 [[package]]
@@ -4333,17 +4324,7 @@ name = "zalgo-codec-macro"
 version = "0.1.27"
 dependencies = [
  "syn 2.0.65",
- "zalgo-codec-common 0.11.1",
-]
-
-[[package]]
-name = "zalgo-codec-macro"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf1649eddbf2def6c59242b1805682336c6cdd655effab3d281db96bbcc7bab6"
-dependencies = [
- "syn 2.0.65",
- "zalgo-codec-common 0.11.1",
+ "zalgo-codec-common",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4306,17 +4306,8 @@ dependencies = [
  "rand",
  "rfd",
  "unicode-segmentation",
- "zalgo-codec-common 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zalgo-codec-common 0.11.1",
  "zalgo-codec-macro 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "zalgo-codec-common"
-version = "0.11.1"
-dependencies = [
- "criterion",
- "rand",
- "serde",
 ]
 
 [[package]]
@@ -4329,11 +4320,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "zalgo-codec-common"
+version = "0.12.0"
+dependencies = [
+ "criterion",
+ "rand",
+ "serde",
+]
+
+[[package]]
 name = "zalgo-codec-macro"
 version = "0.1.27"
 dependencies = [
  "syn 2.0.65",
- "zalgo-codec-common 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zalgo-codec-common 0.11.1",
 ]
 
 [[package]]
@@ -4343,7 +4343,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf1649eddbf2def6c59242b1805682336c6cdd655effab3d281db96bbcc7bab6"
 dependencies = [
  "syn 2.0.65",
- "zalgo-codec-common 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zalgo-codec-common 0.11.1",
 ]
 
 [[package]]

--- a/codec/Cargo.toml
+++ b/codec/Cargo.toml
@@ -12,8 +12,8 @@ description = "Convert an ASCII text string into a single unicode grapheme clust
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-zalgo-codec-common = "0.11.1"
-zalgo-codec-macro = {version = "0.1.27", optional = true}
+zalgo-codec-common = {path = "../common"}
+zalgo-codec-macro = {path = "../macro", optional = true}
 anyhow = {version = "1.0", optional = true}
 iced = {version = "0.12", optional = true}
 rfd = {version = "0.14", optional = true}

--- a/codec/Cargo.toml
+++ b/codec/Cargo.toml
@@ -39,8 +39,9 @@ serde = ["zalgo-codec-common/serde"]
 # Enables the proc-macros [`zalgo_embed`] and [`zalgofy`]
 macro = ["dep:zalgo-codec-macro"]
 
-# Enables the library to link to the standard library.
-# Used to implement the [`std::error::Error`] trait for [`zalgo_codec_common::Error`].
+# Implements the [`std::error::Error`] trait from the standard library for [`zalgo_codec::Error`], 
+# and enables it to capture a [`Backtrace`](std::backtrace::Backtrace). Without this feature the crate is #![no_std],
+# but still uses the `alloc` crate.
 std = ["zalgo-codec-common/std"]
 
 # docs.rs-specific configuration. Taken from <https://stackoverflow.com/a/61417700/>.

--- a/codec/src/lib.rs
+++ b/codec/src/lib.rs
@@ -56,9 +56,10 @@
 //! # }
 //! ```
 //!
-//! # Features
+//! # Feature flags
 //!
-//! `std` *(enabled by default)*: implements the [`std::error::Error`] trait for the provided [`Error`] type.
+//! `std` *(enabled by default)*: implements the [`std::error::Error`] trait for the provided [`Error`] type,
+//! and enables it to capture a [`Backtrace`](std::backtrace::Backtrace).
 //! If this feature is not enabled the library is `#[no_std]`, but still uses the `alloc` crate.
 //!
 //! `serde`: implements the `Serialize` and `Deserialize` traits from [`serde`](https://crates.io/crates/serde) for [`ZalgoString`].

--- a/common/CHANGELOG.md
+++ b/common/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This document contains all changes to the crate since version 0.9.4.
 
+## 0.12.0
+
+### Breaking changes
+
+ - Added a backtrace to the `Error` type, and as a result the error type no longer implements `Clone`, `PartialEq`, `Eq`, or `Hash`.
+
 ## 0.11.1
 
  - Add links to local versions of licenses.

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -31,7 +31,9 @@ default = ["std"]
 # Implements the [`Serialize`] and [`Deserialize`] traits from serde for the [`ZalgoString`] struct.
 serde = ["dep:serde"]
 
-# Implements the [`std::error::Error`] trait for [`zalgo_codec_common::Error`]
+# Implements the [`std::error::Error`] trait from the standard library for [`zalgo_codec_common::Error`], 
+# and enables it to capture a [`Backtrace`](std::backtrace::Backtrace). Without this feature the crate is #![no_std],
+# but still uses the `alloc` crate.
 std = []
 
 [[bench]]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zalgo-codec-common"
 authors = ["Johanna Sörngård <jsorngard@gmail.com>", "Scott Conner"]
-version = "0.11.1"
+version = "0.12.0"
 edition = "2021"
 keywords = ["unicode", "obfuscation", "encoding", "zalgo"]
 categories = ["encoding", "text-processing"]

--- a/common/src/error.rs
+++ b/common/src/error.rs
@@ -117,10 +117,16 @@ impl Error {
     }
 
     #[cfg(feature = "std")]
-    /// Returns a [`Backtrace`](std::backtrace::Backtrace) that was captured when the error was created.
+    /// Returns a reference to a [`Backtrace`](std::backtrace::Backtrace) that was captured when the error was created.
     #[inline]
     pub fn backtrace(&self) -> &std::backtrace::Backtrace {
         &self.backtrace
+    }
+
+    #[cfg(feature = "std")]
+    /// Converts the `Error` into a [`Backtrace`](std::backtrace::Backtrace) that was captured when the error was created.
+    pub fn into_backtrace(self) -> std::backtrace::Backtrace {
+        self.backtrace
     }
 }
 

--- a/common/src/error.rs
+++ b/common/src/error.rs
@@ -134,12 +134,11 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "can not encode {:?} character at string index {}, on line {} at column {}: {}",
+            "can not encode {:?} character at string index {}, on line {} at column {}",
             self.char(),
             self.index(),
             self.line(),
             self.column(),
-            self.backtrace(),
         )
     }
 }

--- a/common/src/error.rs
+++ b/common/src/error.rs
@@ -1,6 +1,8 @@
 //! Contains the definition of the error type used by the encoding functions in the crate.
 
 use core::fmt;
+#[cfg(feature = "std")]
+use std::backtrace::Backtrace;
 
 #[derive(Debug)]
 /// The error returned by [`zalgo_encode`](crate::zalgo_encode), [`ZalgoString::new`](crate::ZalgoString::new), and [`zalgo_wrap_python`](crate::zalgo_wrap_python)
@@ -13,7 +15,7 @@ pub struct Error {
     column: usize,
     index: usize,
     #[cfg(feature = "std")]
-    backtrace: std::backtrace::Backtrace,
+    backtrace: Backtrace,
 }
 
 impl Error {
@@ -37,7 +39,7 @@ impl Error {
             column,
             index,
             #[cfg(feature = "std")]
-            backtrace: std::backtrace::Backtrace::capture(),
+            backtrace: Backtrace::capture(),
         }
     }
 
@@ -117,9 +119,12 @@ impl Error {
     }
 
     #[cfg(feature = "std")]
-    /// Returns a reference to a [`Backtrace`](std::backtrace::Backtrace) that was captured when the error was created.
+    /// Returns a reference to a [`Backtrace`] that was captured when the error was created.
+    ///
+    /// See the documentation of [`Backtrace`] for more information about how to make it
+    /// show more information when displayed.
     #[inline]
-    pub fn backtrace(&self) -> &std::backtrace::Backtrace {
+    pub fn backtrace(&self) -> &Backtrace {
         &self.backtrace
     }
 }

--- a/common/src/error.rs
+++ b/common/src/error.rs
@@ -117,7 +117,7 @@ impl Error {
     }
 
     #[cfg(feature = "std")]
-    /// Returns a [`Backtrace`] that was captured when the error was created.
+    /// Returns a [`Backtrace`](std::backtrace::Backtrace) that was captured when the error was created.
     #[inline]
     pub fn backtrace(&self) -> &std::backtrace::Backtrace {
         &self.backtrace
@@ -128,11 +128,12 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "can not encode {:?} character at string index {}, on line {} at column {}: ",
+            "can not encode {:?} character at string index {}, on line {} at column {}: {}",
             self.char(),
             self.index(),
             self.line(),
             self.column(),
+            self.backtrace(),
         )
     }
 }

--- a/common/src/error.rs
+++ b/common/src/error.rs
@@ -121,7 +121,7 @@ impl Error {
     #[cfg(feature = "std")]
     /// Returns a reference to a [`Backtrace`] that was captured when the error was created.
     ///
-    /// See the documentation of [`Backtrace`] for more information about how to make it
+    /// See the documentation of [`Backtrace::capture`] for more information about how to make it
     /// show more information when displayed.
     #[inline]
     pub fn backtrace(&self) -> &Backtrace {

--- a/common/src/error.rs
+++ b/common/src/error.rs
@@ -122,12 +122,6 @@ impl Error {
     pub fn backtrace(&self) -> &std::backtrace::Backtrace {
         &self.backtrace
     }
-
-    #[cfg(feature = "std")]
-    /// Converts the `Error` into a [`Backtrace`](std::backtrace::Backtrace) that was captured when the error was created.
-    pub fn into_backtrace(self) -> std::backtrace::Backtrace {
-        self.backtrace
-    }
 }
 
 impl fmt::Display for Error {

--- a/common/src/error.rs
+++ b/common/src/error.rs
@@ -1,7 +1,6 @@
 //! Contains the definition of the error type used by the encoding functions in the crate.
 
 use core::fmt;
-use std::backtrace::Backtrace;
 
 #[derive(Debug)]
 /// The error returned by [`zalgo_encode`](crate::zalgo_encode), [`ZalgoString::new`](crate::ZalgoString::new), and [`zalgo_wrap_python`](crate::zalgo_wrap_python)
@@ -13,7 +12,8 @@ pub struct Error {
     line: usize,
     column: usize,
     index: usize,
-    backtrace: Backtrace,
+    #[cfg(feature = "std")]
+    backtrace: std::backtrace::Backtrace,
 }
 
 impl Error {
@@ -36,7 +36,8 @@ impl Error {
             line,
             column,
             index,
-            backtrace: Backtrace::capture(),
+            #[cfg(feature = "std")]
+            backtrace: std::backtrace::Backtrace::capture(),
         }
     }
 
@@ -115,8 +116,10 @@ impl Error {
         self.index
     }
 
+    #[cfg(feature = "std")]
     /// Returns a [`Backtrace`] that was captured when the error was created.
-    pub fn backtrace(&self) -> &Backtrace {
+    #[inline]
+    pub fn backtrace(&self) -> &std::backtrace::Backtrace {
         &self.backtrace
     }
 }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -49,9 +49,10 @@
 //! # Ok::<(), Error>(())
 //! ```
 //!
-//! # Features
+//! # Feature flags
 //!
-//! `std` *(enabled by default)*: implements the [`std::error::Error`] trait for the provided [`Error`] type.
+//! `std` *(enabled by default)*: implements the [`std::error::Error`] trait for the provided [`Error`] type,
+//! and enables it to capture a [`Backtrace`](std::backtrace::Backtrace).
 //! If this feature is not enabled the library is `#[no_std]`, but still uses the `alloc` crate.
 //!
 //! `serde`: implements the [`Serialize`](serde::Serialize) and [`Deserialize`](serde::Deserialize) traits

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -16,5 +16,5 @@ proc-macro = true
 
 
 [dependencies]
-zalgo-codec-common = "0.11.1"
+zalgo-codec-common = {path = "../common"}
 syn = "2.0"


### PR DESCRIPTION
This PR adds a backtrace to the `Error` type and a function to access it with. As a result it no longer implements the traits `Clone`, `PartialEq`, `Eq`, or `Hash`.