### PR TITLE
Remove `--cfg docsrs` attribute from `Cargo.toml` on `docs.rs`

### DIFF
--- a/codec/Cargo.toml
+++ b/codec/Cargo.toml
@@ -44,12 +44,9 @@ macro = ["dep:zalgo-codec-macro"]
 # but still uses the `alloc` crate.
 std = ["zalgo-codec-common/std"]
 
-# docs.rs-specific configuration. Taken from <https://stackoverflow.com/a/61417700/>.
 [package.metadata.docs.rs]
 # Document all features.
 all-features = true
-# Enable the docsrs configuration attribute on docs.rs
-rustdoc-args = ["--cfg", "docsrs"]
 
 [[bin]]
 name = "zalgo_codec"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -18,12 +18,9 @@ serde = {version = "1.0", default-features = false, features = ["alloc", "derive
 criterion = {version = "0.5", features = ["html_reports"]}
 rand = "0.8"
 
-# docs.rs-specific configuration. Taken from <https://stackoverflow.com/a/61417700/>.
 [package.metadata.docs.rs]
 # Document all features.
 all-features = true
-# Enable the docsrs configuration attribute on docs.rs
-rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = ["std"]


### PR DESCRIPTION
docs.rs provides that on their own, so we don't have to define it.