### PR TITLE
Add support for `rkyv`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2113,6 +2113,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "munge"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64142d38c84badf60abf06ff9bd80ad2174306a5b11bd4706535090a30a419df"
+dependencies = [
+ "munge_macro",
+]
+
+[[package]]
+name = "munge_macro"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bb5c1d8184f13f7d0ccbeeca0def2f9a181bce2624302793005f5ca8aa62e5e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
 name = "naga"
 version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2714,6 +2734,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d84d1d7a6ac92673717f9f6d1518374ef257669c24ebc5ac25d5033828be58"
 
 [[package]]
+name = "ptr_meta"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe9e76f66d3f9606f44e45598d155cb13ecf09f4a28199e48daf8c8fc937ea90"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca414edb151b4c8d125c12566ab0d74dc9cdba36fb80eb7b848c15f495fd32d1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2729,6 +2769,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rancor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf5f7161924b9d1cea0e4cabc97c372cea92b5f927fc13c6bca67157a0ad947"
+dependencies = [
+ "ptr_meta",
 ]
 
 [[package]]
@@ -2875,6 +2924,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
+name = "rend"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc8d57aa48e8477046d7d6296d920a1f50bbbaf45047ec46c52f6d6cccea7ef7"
+
+[[package]]
 name = "renderdoc-sys"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2901,6 +2956,35 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a1dfb7c03271e31aad881e521cfe25bda0206ee94b1af152957f4f49e25ee23"
+dependencies = [
+ "bytes",
+ "hashbrown",
+ "indexmap",
+ "munge",
+ "ptr_meta",
+ "rancor",
+ "rend",
+ "rkyv_derive",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa3ca4a30c576aeb76aea84370da286f74d12d32029da8caec3d53b5a36a7539"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3584,6 +3668,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 
 [[package]]
 name = "version_check"
@@ -4504,8 +4594,8 @@ dependencies = [
  "rand",
  "rfd",
  "unicode-segmentation",
- "zalgo-codec-common 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zalgo-codec-macro 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zalgo-codec-common 0.12.0",
+ "zalgo-codec-macro",
 ]
 
 [[package]]
@@ -4514,6 +4604,7 @@ version = "0.12.0"
 dependencies = [
  "criterion",
  "rand",
+ "rkyv",
  "serde",
 ]
 
@@ -4522,23 +4613,10 @@ name = "zalgo-codec-common"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4de25b8dc1eda38c2e99d741d3d7c205c7687d42bc2ce86f24ec53967ed86a35"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "zalgo-codec-macro"
 version = "0.1.28"
-dependencies = [
- "syn 2.0.77",
- "zalgo-codec-common 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "zalgo-codec-macro"
-version = "0.1.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e961188f0c2e6454dceaf67f66a613c2a93cadedc50815ab8512218c05e23cab"
 dependencies = [
  "syn 2.0.77",
  "zalgo-codec-common 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/codec/.markdownlint.json
+++ b/codec/.markdownlint.json
@@ -1,0 +1,6 @@
+{
+    "no-inline-html": {
+        "allowed_elements": ["br"]
+    }
+    
+}

--- a/codec/CHANGELOG.md
+++ b/codec/CHANGELOG.md
@@ -1,17 +1,21 @@
 # Changelog
 
-This document contains the changes made to the crate since version 0.9.5. This crate combines the `common` and `macro` crates into one, adds some tests, and defines the test executable that is built with the "binary" and/or "gui" features. 
-See [common/CHANGELOG.md](../common/CHANGELOG.md) for the changes made to the non-macro parts of the crate,
-and [macro/CHANGELOG.md](../macro/CHANGELOG.md) for the changes made to the macros.
+This document contains the changes made to the crate since version 0.9.5.
+This crate combines the `common` and `macro` crates into one, adds some tests,
+and defines the test executable that is built with the "binary" and/or "gui" features.
+See [common/CHANGELOG.md](../common/CHANGELOG.md) for the changes made to the
+non-macro parts of the crate, and [macro/CHANGELOG.md](../macro/CHANGELOG.md)
+for the changes made to the macros.
 
 ## 0.12.0
 
- - Update `zalgo-codec-common` dependency. For more information about breaking changes see its changelog.
+- Update `zalgo-codec-common` dependency. For more information about breaking
+ changes see its changelog.
 
 ## 0.11.1
 
- - Add links to local versions of licenses.  
- - Add docs.rs badge.
+- Add links to local versions of licenses.  
+- Add docs.rs badge.
 
 ## 0.11.0
 
@@ -33,14 +37,14 @@ and [macro/CHANGELOG.md](../macro/CHANGELOG.md) for the changes made to the macr
 
 ## 0.10.1
 
- - Change the links to licenses in the readme to be compatible with crates.io.
- - Update `zalgo-codec-common` and `zalgo-codec-macro` dependencies
+- Change the links to licenses in the readme to be compatible with crates.io.
+- Update `zalgo-codec-common` and `zalgo-codec-macro` dependencies
 
 ## 0.10.0
 
- - Make `anyhow` an optional dependency that is only enabled when the binary is built.
- - Update `zalgo-codec-common` and `zalgo-codec-macro` dependencies
+- Make `anyhow` an optional dependency that is only enabled when the binary is built.
+- Update `zalgo-codec-common` and `zalgo-codec-macro` dependencies
 
 ## 0.9.6
 
- - Update `zalgo-codec-common` and `zalgo-codec-macro` dependencies
+- Update `zalgo-codec-common` and `zalgo-codec-macro` dependencies

--- a/codec/Cargo.toml
+++ b/codec/Cargo.toml
@@ -12,13 +12,13 @@ description = "Convert an ASCII text string into a single unicode grapheme clust
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-zalgo-codec-common = "0.12.0"
-zalgo-codec-macro = {version = "0.1.28", optional = true}
-anyhow = {version = "1.0", optional = true}
-iced = {version = "0.12", optional = true}
-rfd = {version = "0.14", optional = true}
-cli-clipboard = {version = "0.4", optional = true}
-clap = {version = "4.5", features = ["derive"], optional = true}
+zalgo-codec-common = {path = "../common"}
+zalgo-codec-macro = { path = "../macro", optional = true }
+anyhow = { version = "1.0", optional = true }
+iced = { version = "0.12", optional = true }
+rfd = { version = "0.14", optional = true }
+cli-clipboard = { version = "0.4", optional = true }
+clap = { version = "4.5", features = ["derive"], optional = true }
 
 [dev-dependencies]
 rand = "0.8"
@@ -33,15 +33,17 @@ binary = ["std", "dep:clap", "dep:anyhow"]
 # Builds an optional GUI into the binary.
 gui = ["binary", "dep:iced", "dep:rfd", "dep:cli-clipboard"]
 
-# Implements the [`Serialize`] and [`Deserialize`] traits from serde for [`ZalgoString`].
+# Derives the `Serialize` and `Deserialize` traits from [`serde`](https://crates.io/crates/serde) for the `ZalgoString` struct.
 serde = ["zalgo-codec-common/serde"]
 
-# Enables the proc-macros [`zalgo_embed!`] and [`zalgofy!`]
+# Derives the `Serialize`, `Deserialize`, and `Archive` traits from [`rkyv`](https://crates.io/crates/rkyv) for the `ZalgoString` struct.
+rkyv = ["zalgo-codec-common/rkyv"]
+
+# Enables the proc-macros `zalgo_embed!` and `zalgofy!`
 macro = ["dep:zalgo-codec-macro"]
 
-# Implements the [`std::error::Error`] trait from the standard library for [`zalgo_codec::Error`], 
-# and enables it to capture a [`Backtrace`](std::backtrace::Backtrace). Without this feature the crate is #![no_std],
-# but still uses the `alloc` crate.
+# Enables the `Error` type to capture a `Backtrace`.
+# Without this feature the crate is `no_std` compatible, but still uses the `alloc` crate.
 std = ["zalgo-codec-common/std"]
 
 [package.metadata.docs.rs]

--- a/codec/README.md
+++ b/codec/README.md
@@ -1,4 +1,4 @@
-# zalgo_codec 
+# zalgo_codec
 
 [![Static Badge](https://img.shields.io/badge/github-JSorngard%2Fzalgo__codec-8da0cb?logo=github)](https://github.com/JSorngard/zalgo_codec)
 [![Crates.io Version](https://img.shields.io/crates/v/zalgo_codec?logo=rust)](https://crates.io/crates/zalgo-codec)
@@ -6,29 +6,39 @@
 [![Build Status](https://github.com/JSorngard/zalgo_codec/actions/workflows/rust.yml/badge.svg)](https://github.com/JSorngard/zalgo_codec/actions/workflows/rust.yml)
 [![codecov](https://codecov.io/gh/JSorngard/zalgo_codec/graph/badge.svg?token=X7TTODVC8I)](https://codecov.io/gh/JSorngard/zalgo_codec)
 
-This crate lets you convert an ASCII text string into a single unicode grapheme cluster and back. 
-It also provides a procedural macro that lets you take source code that's been converted into such a grapheme cluster and compile it as if it was never zalgo-ified.
+This crate lets you convert an ASCII text string into a single unicode grapheme
+cluster and back.
+It also provides a procedural macro that lets you take source code that's been
+converted into such a grapheme cluster and compile it as if it was never zalgo-ified.
 This lets you reach new lows in the field of self-documenting code.
 
 The encoded string will be ~2 times larger than the original in terms of bytes.
 
-Additionally the crate provides a function to encode Python code and wrap the result in a decoder that decodes and executes it such that the result retains the functionality of the original code.
+Additionally the crate provides a function to encode Python code and wrap the
+result in a decoder that decodes and executes it such that the result retains the
+functionality of the original code.
 
 ## Examples
 
 Encode a string to a grapheme cluster with `zalgo_encode`:
+
 ```rust
 let s = "Zalgo";
 let encoded = zalgo_encode(s)?;
 assert_eq!(encoded, "É̺͇͌͏");
 ```
+
 Decode a grapheme cluster back into a string with `zalgo_decode`:
+
 ```rust
 let encoded = "É̺͇͌͏";
 let s = zalgo_decode(encoded)?;
 assert_eq!(s, "Zalgo");
 ```
-The `ZalgoString` type can be used to encode a string and handle the result in various ways:
+
+The `ZalgoString` type can be used to encode a string and handle the result in
+various ways:
+
 ```rust
 let s = "Zalgo";
 let zstr = ZalgoString::new(s)?;
@@ -61,13 +71,16 @@ let z = zalgo_embed!("È͙̋̀͘");
 assert_eq!(z, x + y);
 ```
 
-We can also do the opposite of [obfstr](https://crates.io/crates/obfstr): obfuscate a string while coding and deobfuscate it during compile time
+We can also do the opposite of [obfstr](https://crates.io/crates/obfstr): obfuscate
+a string while coding and deobfuscate it during compile time
+
 ```rust
 let secret_string = zalgo_embed!("Ê̤͏͎͔͔͈͉͓͍̇̀͒́̈́̀̀ͅ͏͍́̂");
 assert_eq!(secret_string, "Don't read this mom!");
 ```
 
-The cursed character at the bottom of this section is the standard "Lorem ipsum" encoded with the encoding function in this crate.
+The cursed character at the bottom of this section is the standard "Lorem ipsum"
+encoded with the encoding function in this crate.
 
 <br/>
 <br/>
@@ -86,25 +99,44 @@ E̬͏͍͉͓͕͍͒̀͐̀̈́ͅ͏͌͏͓͉͔͍͔͒̀̀́̌̀̓ͅ͏͎͓͔͔͕̓͒ͅͅ�
 <br/>
 
 ## Explanation
-Characters U+0300–U+036F are the combining characters for unicode Latin. The fun thing about combining characters is that you can add as many of these characters as you like to the original character and it does not create any new symbols, it only adds symbols on top of the character. It's supposed to be used in order to create characters such as `á` by taking a normal `a` and adding another character to give it the mark (U+301, in this case). Fun fact, Unicode doesn't specify any limit on the number of these characters. Conveniently, this gives us 112 different characters we can map to, which nicely maps to the ASCII character range 0x20 -> 0x7F, aka all the non-control characters. The only issue is that we can't have new lines in this system, so to fix that, we can simply map 0x7F (DEL) to 0x0A (LF). This can be represented as `(CHARACTER - 11) % 133 - 21`, and decoded with `(CHARACTER + 22) % 133 + 10`.  
 
+Characters U+0300–U+036F are the combining characters for unicode Latin.
+The fun thing about combining characters is that you can add as many of these
+characters as you like to the original character and it does not create any new symbols,
+it only adds symbols on top of the character. It's supposed to be used in order
+to create characters such as `á` by taking a normal `a` and adding another
+character to give it the mark (U+301, in this case).
+Fun fact,Unicode doesn't specify any limit on the number of these characters.
+Conveniently, this gives us 112 different characters we can map to,
+which nicely maps to the ASCII character range 0x20 -> 0x7F,
+aka all the non-control characters. The only issue is that we can't have new lines
+in this system, so to fix that, we can simply map 0x7F (DEL) to 0x0A (LF).
+This can be represented as `(CHARACTER - 11) % 133 - 21`, and decoded with
+`(CHARACTER + 22) % 133 + 10`.
 
 ## Experiment with the codec
 
 There is an executable available for experimenting with the codec on text and files.
 It can also be used to generate grapheme clusters from source code for use with `zalgo_embed!`.
-It can be installed with `cargo install zalgo-codec --features binary`. 
-You can optionally enable the `gui` feature during installation to include a rudimentary GUI mode for the program.
+It can be installed with `cargo install zalgo-codec --features binary`.
+You can optionally enable the `gui` feature during installation to include a
+rudimentary GUI mode for the program.
 
 ## Links
-The crate is based on the encoding and decoding functions [originally written in Python](https://github.com/DaCoolOne/DumbIdeas/tree/main/reddit_ph_compressor) by Scott Conner. They were first presented in [this post](https://www.reddit.com/r/ProgrammerHumor/comments/yqof9f/the_most_upvoted_comment_picks_the_next_line_of/ivrd9ur/?context=3) together with the above explanation.
+
+The crate is based on the encoding and decoding functions
+[originally written in Python](https://github.com/DaCoolOne/DumbIdeas/tree/main/reddit_ph_compressor)
+by Scott Conner. They were first presented in [this post](https://www.reddit.com/r/ProgrammerHumor/comments/yqof9f/the_most_upvoted_comment_picks_the_next_line_of/ivrd9ur/?context=3)
+together with the above explanation.
 
 ## License
 
 Licensed under either of
 
- * Apache License, Version 2.0 ([LICENSE-APACHE](https://github.com/JSorngard/zalgo_codec/blob/main/codec/LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
- * MIT license ([LICENSE-MIT](https://github.com/JSorngard/zalgo_codec/blob/main/codec/LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+- Apache License, Version 2.0 ([LICENSE-APACHE](https://github.com/JSorngard/zalgo_codec/blob/main/codec/LICENSE-APACHE)
+ or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](https://github.com/JSorngard/zalgo_codec/blob/main/codec/LICENSE-MIT)
+ or <http://opensource.org/licenses/MIT>)
 
 at your option.
 

--- a/codec/src/lib.rs
+++ b/codec/src/lib.rs
@@ -62,7 +62,7 @@
 //! If this feature is not enabled the library is `no_std` compatible, but still uses the `alloc` crate.
 //!
 //! `serde`: derives the `Serialize` and `Deserialize` traits from [`serde`](https://docs.rs/serde) for [`ZalgoString`].
-//! 
+//!
 //! `rkyv`: derives the `Serialize`, `Deserialize`, and `Archive` traits from [`rkyv`](https://docs.rs/rkyv) for [`ZalgoString`].
 //!
 //! `macro` *(enabled by default)*: exports the procedural macros [`zalgo_embed!`] and [`zalgofy!`].

--- a/codec/src/lib.rs
+++ b/codec/src/lib.rs
@@ -58,11 +58,12 @@
 //!
 //! # Feature flags
 //!
-//! `std` *(enabled by default)*: implements the [`std::error::Error`] trait for the provided [`Error`] type,
-//! and enables it to capture a [`Backtrace`](std::backtrace::Backtrace).
-//! If this feature is not enabled the library is `#![no_std]`, but still uses the `alloc` crate.
+//! `std` *(enabled by default)*: enables [`Error`] to capture a [`Backtrace`](std::backtrace::Backtrace).
+//! If this feature is not enabled the library is `no_std` compatible, but still uses the `alloc` crate.
 //!
-//! `serde`: implements the `Serialize` and `Deserialize` traits from [`serde`](https://crates.io/crates/serde) for [`ZalgoString`].
+//! `serde`: derives the `Serialize` and `Deserialize` traits from [`serde`](https://docs.rs/serde) for [`ZalgoString`].
+//! 
+//! `rkyv`: derives the `Serialize`, `Deserialize`, and `Archive` traits from [`rkyv`](https://docs.rs/rkyv) for [`ZalgoString`].
 //!
 //! `macro` *(enabled by default)*: exports the procedural macros [`zalgo_embed!`] and [`zalgofy!`].
 //!   

--- a/common/.markdownlint.json
+++ b/common/.markdownlint.json
@@ -1,0 +1,5 @@
+{
+    "no-duplicate-heading": {
+    "siblings_only": true
+  }
+}

--- a/common/CHANGELOG.md
+++ b/common/CHANGELOG.md
@@ -6,11 +6,12 @@ This document contains all changes to the crate since version 0.9.4.
 
 ### Breaking changes
 
- - Added a backtrace to the `Error` type, and as a result the error type no longer implements `Clone`, `PartialEq`, `Eq`, or `Hash`.
+- Added a backtrace to the `Error` type, and as a result the error type no longer
+ implements `Clone`, `PartialEq`, `Eq`, or `Hash`.
 
 ## 0.11.1
 
- - Add links to local versions of licenses.
+- Add links to local versions of licenses.
 
 ## 0.11.0
 
@@ -23,49 +24,65 @@ This document contains all changes to the crate since version 0.9.4.
 
 - Add `Error::char` function.
 - Add `Error::index` function.
-- Implement the `Default` trait for `ZalgoString`. It just allocates a buffer with a single `'E'`.
+- Implement the `Default` trait for `ZalgoString`. It just allocates a buffer
+ with a single `'E'`.
 - Add `ZalgoString::with_capacity` function.
 - Add `ZalgoString::encode_and_push_str` function.
 
 ## 0.10.4
 
 - Implement the `Index` trait for the different range types for `ZalgoString`.
-- Add the `get` and `get_unchecked` functions to `ZalgoString` that work the same as `str::get` and `str::get_unchecked`.
-- Add `into_combining_chars` to `ZalgoString` that returns a string that contains only the combining charaters of the grapheme cluster (that is, without the initial "E").
+- Add the `get` and `get_unchecked` functions to `ZalgoString` that work the same
+ as `str::get` and `str::get_unchecked`.
+- Add `into_combining_chars` to `ZalgoString` that returns a string that contains
+ only the combining charaters of the grapheme cluster
+ (that is, without the initial "E").
 
 ## 0.10.3
 
- - Add `truncate` and `clear` to `ZalgoString`.
+- Add `truncate` and `clear` to `ZalgoString`.
 
 ## 0.10.2
 
- - Add `reserve` and `reserve_exact` to `ZalgoString`.
+- Add `reserve` and `reserve_exact` to `ZalgoString`.
 
 ## 0.10.1
 
- - Change the links to licenses in the readme to be compatible with crates.io.
+- Change the links to licenses in the readme to be compatible with crates.io.
 
 ## 0.10.0
 
 ### Breaking changes
 
- - Changed the `encode_and_push_str` method to `push_zalgo_str`, which takes a reference to an already encoded `ZalgoString` for an API that doesn't hide as many allocations. To port to this version simply change all 
-   ```rust
-   zs.encode_and_push_str(s)?;
-   ```
-   to
-   ```rust
-   zs.push_zalgo_str(&ZalgoString::new(s)?);
-   ```
-   which is what `encode_and_push_str` did under the hood.
+- Changed the `encode_and_push_str` method to `push_zalgo_str`, which takes a
+ reference to an already encoded `ZalgoString` for an API that doesn't hide as
+ many allocations. To port to this version simply change all
+
+  ```rust
+  zs.encode_and_push_str(s)?;
+  ```
+
+  to
+  
+  ```rust
+  zs.push_zalgo_str(&ZalgoString::new(s)?); 
+  ```
+
+  which is what `encode_and_push_str` did under the hood.
 
 ### Minor changes
 
- - Make the implementation of `PartialEq` for `ZalgoString` and other string types symmetric. That is, it's now possible to write equality checks that involve a `ZalgoString` in both directions, so both `assert_ne!(ZalgoString::new("stuff")?, "stuff");` and `assert_ne!("stuff", ZalgoString::new("stuff")?);` compile.
- - Implement `Add` and `AddAssign` to enable the user to append the encoded contents of one `ZalgoString` onto the end of another.
- - Documentation improvements
+- Make the implementation of `PartialEq` for `ZalgoString` and other string types
+ symmetric.
+ That is, it's now possible to write equality checks that involve a `ZalgoString`
+ in both directions,
+ so both `assert_ne!(ZalgoString::new("stuff")?, "stuff");` and
+ `assert_ne!("stuff", ZalgoString::new("stuff")?);` compile.
+- Implement `Add` and `AddAssign` to enable the user to append the encoded
+ contents of one `ZalgoString` onto the end of another.
+- Documentation improvements.
 
 ## 0.9.5
 
- - Add `as_combining_chars` and `encode_and_push_str` to `ZalgoString`
- - Documentation improvements
+- Add `as_combining_chars` and `encode_and_push_str` to `ZalgoString`
+- Documentation improvements.

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -12,7 +12,8 @@ repository = "https://github.com/JSorngard/zalgo_codec/tree/main/common"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = {version = "1.0", default-features = false, features = ["alloc", "derive"], optional = true}
+serde = { version = "1.0", default-features = false, features = ["alloc", "derive"], optional = true }
+rkyv = { version = "0.8", default-features = false, features = ["alloc"], optional = true }
 
 [dev-dependencies]
 criterion = {version = "0.5", features = ["html_reports"]}
@@ -25,13 +26,15 @@ all-features = true
 [features]
 default = ["std"]
 
-# Implements the [`Serialize`] and [`Deserialize`] traits from serde for the [`ZalgoString`] struct.
+# Derives the `Serialize` and `Deserialize` traits from [`serde`](https://crates.io/crates/serde) for the `ZalgoString` struct.
 serde = ["dep:serde"]
 
-# Implements the [`std::error::Error`] trait from the standard library for [`zalgo_codec_common::Error`], 
-# and enables it to capture a [`Backtrace`](std::backtrace::Backtrace). Without this feature the crate is #![no_std],
-# but still uses the `alloc` crate.
-std = []
+# Derives the `Serialize`, `Deserialize`, and `Archive` traits from [`rkyv`](https://crates.io/crates/rkyv) for the `ZalgoString` struct.
+rkyv = ["dep:rkyv"]
+
+# Enables the `Error` type to capture a `Backtrace`.
+# Without this feature the crate is `no_std` compatible, but still uses the `alloc` crate.
+std = ["serde?/std", "rkyv?/std"]
 
 [[bench]]
 name = "codec_bench"

--- a/common/README.md
+++ b/common/README.md
@@ -11,18 +11,24 @@ and the second is to use the `ZalgoString` wrapper type.
 ## Examples
 
 Encode a string to a grapheme cluster with `zalgo_encode`:
+
 ```rust
 let s = "Zalgo";
 let encoded = zalgo_encode(s)?;
 assert_eq!(encoded, "É̺͇͌͏");
 ```
+
 Decode a grapheme cluster back into a string:
+
 ```rust
 let encoded = "É̺͇͌͏";
 let s = zalgo_decode(encoded)?;
 assert_eq!(s, "Zalgo");
 ```
-The `ZalgoString` type can be used to encode a string and handle the result in various ways:
+
+The `ZalgoString` type can be used to encode a string and handle the result in
+various ways:
+
 ```rust
 let s = "Zalgo";
 let zstr = ZalgoString::new(s)?;
@@ -34,6 +40,7 @@ assert_eq!(zstr.decoded_chars().next_back(), Some('o'));
 ```
 
 ## Explanation
+
 Characters U+0300–U+036F are the combining characters for unicode Latin.
 The fun thing about combining characters is that you can add as many of these characters
 as you like to the original character and it does not create any new symbols,
@@ -42,23 +49,28 @@ create characters such as `á` by taking a normal `a` and adding another charac
 to give it the mark (U+301, in this case). Fun fact: Unicode doesn't specify
 any limit on the number of these characters.
 Conveniently, this gives us 112 different characters we can map to,
-which nicely maps to the ASCII character range 0x20 -> 0x7F, aka all the non-control characters.
+which nicely maps to the ASCII character range 0x20 -> 0x7F, aka all the
+non-control characters.
 The only issue is that we can't have new lines in this system, so to fix that,
 we can simply map 0x7F (DEL) to 0x0A (LF).
-This can be represented as `(CHARACTER - 11) % 133 - 21`, and decoded with `(CHARACTER + 22) % 133 + 10`.
+This can be represented as `(CHARACTER - 11) % 133 - 21`, and decoded with
+`(CHARACTER + 22) % 133 + 10`.
 
 ## Experiment with the codec
 
 There is an executable available for experimenting with the codec on text and files.
-It can be installed with `cargo install zalgo-codec --features binary`. 
-You can optionally enable the `gui` feature during installation to include a rudimentary GUI mode for the program.
+It can be installed with `cargo install zalgo-codec --features binary`.
+You can optionally enable the `gui` feature during installation to include a
+rudimentary GUI mode for the program.
 
 ## License
 
 Licensed under either of
 
- * Apache License, Version 2.0 ([LICENSE-APACHE](https://github.com/JSorngard/zalgo_codec/blob/main/common/LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
- * MIT license ([LICENSE-MIT](https://github.com/JSorngard/zalgo_codec/blob/main/common/LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+- Apache License, Version 2.0 ([LICENSE-APACHE](https://github.com/JSorngard/zalgo_codec/blob/main/common/LICENSE-APACHE)
+ or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](https://github.com/JSorngard/zalgo_codec/blob/main/common/LICENSE-MIT)
+ or <http://opensource.org/licenses/MIT>)
 
 at your option.
 

--- a/common/src/error.rs
+++ b/common/src/error.rs
@@ -7,8 +7,6 @@ use std::backtrace::Backtrace;
 #[derive(Debug)]
 /// The error returned by [`zalgo_encode`](crate::zalgo_encode), [`ZalgoString::new`](crate::ZalgoString::new), and [`zalgo_wrap_python`](crate::zalgo_wrap_python)
 /// if they encounter a byte they can not encode.
-///
-/// Only implements the [`Error`](std::error::Error) trait if the `std` feature is enabled.
 pub struct Error {
     unencodable_character: char,
     line: usize,
@@ -142,8 +140,7 @@ impl fmt::Display for Error {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}
 
 #[cfg(test)]
 mod test {

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -51,12 +51,13 @@
 //!
 //! # Feature flags
 //!
-//! `std` *(enabled by default)*: implements the [`std::error::Error`] trait for the provided [`Error`] type,
-//! and enables it to capture a [`Backtrace`](std::backtrace::Backtrace).
-//! If this feature is not enabled the library is `#![no_std]`, but still uses the `alloc` crate.
+//! `std` *(enabled by default)*: enables [`Error`] to capture a [`Backtrace`](std::backtrace::Backtrace).
+//! If this feature is not enabled the library is `no_std` compatible, but still uses the `alloc` crate.
 //!
-//! `serde`: implements the [`Serialize`](serde::Serialize) and [`Deserialize`](serde::Deserialize) traits
-//! from [`serde`](https://crates.io/crates/serde) for [`ZalgoString`].
+//! `serde`: derives the [`serde::Serialize`] and [`serde::Deserialize`] traits
+//! from [`serde`] for [`ZalgoString`].
+//! 
+//! `rkyv`: derives the [`rkyv::Serialize`], [`rkyv::Deserialize`], and [`rkyv::Archive`] traits from [`rkyv`] for [`ZalgoString`].
 //!
 //! # Explanation
 //!

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -56,7 +56,7 @@
 //!
 //! `serde`: derives the [`serde::Serialize`] and [`serde::Deserialize`] traits
 //! from [`serde`] for [`ZalgoString`].
-//! 
+//!
 //! `rkyv`: derives the [`rkyv::Serialize`], [`rkyv::Deserialize`], and [`rkyv::Archive`] traits from [`rkyv`] for [`ZalgoString`].
 //!
 //! # Explanation

--- a/common/src/zalgo_string/mod.rs
+++ b/common/src/zalgo_string/mod.rs
@@ -21,11 +21,9 @@ use std::borrow::Cow;
 /// A [`String`] that has been encoded with [`zalgo_encode`].
 /// This struct can be decoded in-place and also allows iteration over its characters and bytes, both in
 /// decoded and encoded form.
-///
-/// If the `serde` feature is enabled this struct implements the
-/// [`Serialize`](serde::Serialize) and [`Deserialize`](serde::Deserialize) traits.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "rkyv", derive(rkyv::Serialize, rkyv::Deserialize, rkyv::Archive))]
 pub struct ZalgoString(String);
 
 /// Allocates a `String` that contains only the character "E" and no encoded content.

--- a/common/src/zalgo_string/mod.rs
+++ b/common/src/zalgo_string/mod.rs
@@ -23,7 +23,10 @@ use std::borrow::Cow;
 /// decoded and encoded form.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "rkyv", derive(rkyv::Serialize, rkyv::Deserialize, rkyv::Archive))]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Serialize, rkyv::Deserialize, rkyv::Archive)
+)]
 pub struct ZalgoString(String);
 
 /// Allocates a `String` that contains only the character "E" and no encoded content.

--- a/macro/CHANGELOG.md
+++ b/macro/CHANGELOG.md
@@ -4,7 +4,7 @@ This document contains all changes to the crate since 0.1.19
 
 ## 0.1.27
 
- - Add links to local versions of licenses.
+- Add links to local versions of licenses.
 
 ## 0.1.26
 
@@ -20,19 +20,18 @@ This document contains all changes to the crate since 0.1.19
 
 ## 0.1.23
 
- - Update `zalgo-codec-common` dependency.
+- Update `zalgo-codec-common` dependency.
 
 ## 0.1.22
 
- - Change the links to licenses in the readme to be compatible with crates.io.
-
+- Change the links to licenses in the readme to be compatible with crates.io.
 
 ## 0.1.21
 
- - Add the `zalgofy` macro.
- - Documentation improvements.
- - Update `zalgo-codec-common` dependency.
+- Add the `zalgofy` macro.
+- Documentation improvements.
+- Update `zalgo-codec-common` dependency.
 
 ## 0.1.20
 
- - Update `zalgo-codec-common` dependency.
+- Update `zalgo-codec-common` dependency.

--- a/macro/README.md
+++ b/macro/README.md
@@ -12,6 +12,7 @@ The second lets you encode a string into a single grapheme cluster at compile ti
 
 If we run [`zalgo-codec-common::zalgo_encode`](https://docs.rs/zalgo-codec-common/latest/zalgo_codec_common/fn.zalgo_encode.html) on the string "fn square(x: i32) -> i32 {x * x}" we can include the `square` function in our program
 by putting the resulting grapheme cluster inside `zalgo_embed!`:
+
 ```rust
 zalgo_embed!("E͎͓͕͉̞͉͆̀͑́͒̈̀̓̒̉̀̍̀̓̒̀͛̀̊̀͘̚͘͘͝ͅ");
 assert_eq!(square(10), 100);
@@ -21,8 +22,8 @@ assert_eq!(square(10), 100);
 
 Licensed under either of
 
- * Apache License, Version 2.0 ([LICENSE-APACHE](https://github.com/JSorngard/zalgo_codec/blob/main/macro/LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
- * MIT license ([LICENSE-MIT](https://github.com/JSorngard/zalgo_codec/blob/main/macro/LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+- Apache License, Version 2.0 ([LICENSE-APACHE](https://github.com/JSorngard/zalgo_codec/blob/main/macro/LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](https://github.com/JSorngard/zalgo_codec/blob/main/macro/LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
 
 at your option.
 


### PR DESCRIPTION
Also update `Error` to derive the `Error` trait from `core` and format the markdown files with the help of the `markdownlint` extension in vscode.