### PR TITLE
Switch doc and coverage CI jobs to run on Ubuntu instead of Windows

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,7 +54,7 @@ jobs:
     - name: document
       run: cargo +nightly doc --all-features --no-deps
   coverage:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,7 +44,7 @@ jobs:
     - name: build
       run: cargo build --features binary
   doc:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     env:
       RUSTFLAGS: -D warnings
       RUSTDOCFLAGS: --cfg docsrs


### PR DESCRIPTION
Switches the CI jobs that run on Windows to run on Ubuntu instead as this speeds them up a lot.