### PR TITLE
Skip documenting with the binary

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,7 +52,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@nightly
     - name: document
-      run: cargo +nightly doc --all-features --no-deps
+      run: cargo +nightly doc --features macro,std,serde,rkyv --no-deps
   coverage:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This massively speeds up the documentation CI job.