### PR TITLE
Remove explicit lifetimes when they can be elided.

### DIFF
--- a/common/src/zalgo_string/iterators.rs
+++ b/common/src/zalgo_string/iterators.rs
@@ -16,7 +16,7 @@ impl<'a> DecodedBytes<'a> {
     }
 }
 
-impl<'a> Iterator for DecodedBytes<'a> {
+impl Iterator for DecodedBytes<'_> {
     type Item = u8;
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
@@ -63,7 +63,7 @@ impl<'a> Iterator for DecodedBytes<'a> {
     }
 }
 
-impl<'a> DoubleEndedIterator for DecodedBytes<'a> {
+impl DoubleEndedIterator for DecodedBytes<'_> {
     #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
         self.0
@@ -73,8 +73,8 @@ impl<'a> DoubleEndedIterator for DecodedBytes<'a> {
     }
 }
 
-impl<'a> FusedIterator for DecodedBytes<'a> {}
-impl<'a> ExactSizeIterator for DecodedBytes<'a> {}
+impl FusedIterator for DecodedBytes<'_> {}
+impl ExactSizeIterator for DecodedBytes<'_> {}
 
 /// An iterator over the decoded characters of a [`ZalgoString`].
 ///
@@ -90,7 +90,7 @@ impl<'a> DecodedChars<'a> {
     }
 }
 
-impl<'a> Iterator for DecodedChars<'a> {
+impl Iterator for DecodedChars<'_> {
     type Item = char;
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
@@ -118,12 +118,12 @@ impl<'a> Iterator for DecodedChars<'a> {
     }
 }
 
-impl<'a> DoubleEndedIterator for DecodedChars<'a> {
+impl DoubleEndedIterator for DecodedChars<'_> {
     #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
         self.0.next_back().map(char::from)
     }
 }
 
-impl<'a> FusedIterator for DecodedChars<'a> {}
-impl<'a> ExactSizeIterator for DecodedChars<'a> {}
+impl FusedIterator for DecodedChars<'_> {}
+impl ExactSizeIterator for DecodedChars<'_> {}

--- a/common/src/zalgo_string/mod.rs
+++ b/common/src/zalgo_string/mod.rs
@@ -999,7 +999,7 @@ mod test {
     #[test]
     fn test_decoded_bytes() {
         let zs = ZalgoString::new("Zalgo").unwrap();
-        assert_eq!(zs.decoded_bytes().nth(0), Some(b'Z'));
+        assert_eq!(zs.decoded_bytes().next(), Some(b'Z'));
         assert_eq!(zs.decoded_bytes().nth(2), Some(b'l'));
         assert_eq!(zs.decoded_bytes().last(), Some(b'o'));
         let mut dcb = zs.decoded_bytes();
@@ -1012,7 +1012,7 @@ mod test {
     #[test]
     fn test_decoded_chars() {
         let zs = ZalgoString::new("Zalgo").unwrap();
-        assert_eq!(zs.decoded_chars().nth(0), Some('Z'));
+        assert_eq!(zs.decoded_chars().next(), Some('Z'));
         assert_eq!(zs.decoded_chars().nth(2), Some('l'));
         assert_eq!(zs.decoded_chars().last(), Some('o'));
         let mut dcc = zs.decoded_chars();


### PR DESCRIPTION
Also change nth(0) for next().

All the changes of this PR were generated with `cargo clippy --fix` after updating to Rust 1.83.0.