### PR TITLE
Use a matrix in the test CI jobs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,9 +38,15 @@ jobs:
       run: cargo clippy -- -D warnings
       
   test_codec:
+    strategy:
+      matrix:
+        channel: ["stable", "beta"]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        channel {{ $matrix.channel }}
     - uses: taiki-e/install-action@v2
       with:
         tool: cargo-all-features
@@ -123,17 +129,6 @@ jobs:
           tool: cargo-semver-checks
       - name: Verify semver compatibility
         run: cargo semver-checks
-
-  beta_test_codec:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@beta
-    - uses: taiki-e/install-action@v2
-      with:
-        tool: cargo-all-features 
-    - name: Test the codec crate on rust beta
-      run: cargo test-all-features --n-chunks 3 --chunk 1
 
   beta_test_common:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,8 +55,14 @@ jobs:
 
   test_common:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain: [stable, beta]
     steps:
     - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ matrix.toolchain }}
     - uses: taiki-e/install-action@v2
       with:
         tool: cargo-all-features
@@ -129,17 +135,6 @@ jobs:
           tool: cargo-semver-checks
       - name: Verify semver compatibility
         run: cargo semver-checks
-
-  beta_test_common:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@beta
-    - uses: taiki-e/install-action@v2
-      with:
-        tool: cargo-all-features 
-    - name: Test the common crate on rust beta
-      run: cargo test-all-features --n-chunks 3 --chunk 2
 
   beta_test_macro:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,15 +38,15 @@ jobs:
       run: cargo clippy -- -D warnings
       
   test_codec:
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        channel: ["stable", "beta"]
-    runs-on: ubuntu-latest
+        toolchain: [stable, beta]
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@master
       with:
-        channel {{ $matrix.channel }}
+        toolchain: ${{ matrix.channel }}
     - uses: taiki-e/install-action@v2
       with:
         tool: cargo-all-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,7 +46,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: ${{ matrix.channel }}
+        toolchain: ${{ matrix.toolchain }}
     - uses: taiki-e/install-action@v2
       with:
         tool: cargo-all-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -87,14 +87,9 @@ jobs:
       
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        toolchain: [stable, beta]
     steps:
     - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@master
-      with:
-        toolchain: ${{ matrix.toolchain }}
+    - uses: dtolnay/rust-toolchain@stable
     - uses: taiki-e/install-action@v2
       with:
         tool: cargo-all-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -87,8 +87,14 @@ jobs:
       
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain: [stable, beta]
     steps:
     - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ matrix.toolchain }}
     - uses: taiki-e/install-action@v2
       with:
         tool: cargo-all-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -71,8 +71,14 @@ jobs:
 
   test_macro:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain: [stable, beta]
     steps:
     - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ matrix.toolchain }}
     - uses: taiki-e/install-action@v2
       with:
         tool: cargo-all-features
@@ -135,14 +141,3 @@ jobs:
           tool: cargo-semver-checks
       - name: Verify semver compatibility
         run: cargo semver-checks
-
-  beta_test_macro:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@beta
-    - uses: taiki-e/install-action@v2
-      with:
-        tool: cargo-all-features 
-    - name: Test the macro crate on rust beta
-      run: cargo test-all-features --n-chunks 3 --chunk 3


### PR DESCRIPTION
Instead of manually making separate test jobs on stable and beta we can use a github actions matrix. 