### PR TITLE
Remove the initial E from the ZalgoString protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1032,7 +1032,7 @@ dependencies = [
 
 [[package]]
 name = "zalgo-codec"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "zalgo-codec-common"
-version = "0.13.4"
+version = "0.14.0"
 dependencies = [
  "bytecheck",
  "criterion",
@@ -1056,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "zalgo-codec-macro"
-version = "0.1.34"
+version = "0.2.0"
 dependencies = [
  "syn",
  "zalgo-codec-common",

--- a/codec/CHANGELOG.md
+++ b/codec/CHANGELOG.md
@@ -7,6 +7,11 @@ See [common/CHANGELOG.md](../common/CHANGELOG.md) for the changes made to the
 non-macro parts of the crate, and [macro/CHANGELOG.md](../macro/CHANGELOG.md)
 for the changes made to the macros.
 
+## 0.15.0
+
+- Update dependencies. This changes to format to no longer have an initial "E",
+ see the changelog of `zalgo_codec_common` for more information.
+
 ## 0.14.1
 
 - Update dependencies

--- a/codec/Cargo.toml
+++ b/codec/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zalgo-codec"
 authors = ["Johanna Sörngård <jsorngard@gmail.com>", "Scott Conner", "Alex Keizer <alex@keizer.dev>"]
-version = "0.14.1"
+version = "0.15.0"
 edition = "2021"
 keywords = ["unicode", "obfuscation", "encoding", "zalgo"]
 categories = ["encoding", "text-processing"]

--- a/codec/README.md
+++ b/codec/README.md
@@ -12,7 +12,7 @@ It also provides a procedural macro that lets you take source code that's been
 converted into such a grapheme cluster and compile it as if it was never zalgo-ified.
 This lets you reach new lows in the field of self-documenting code.
 
-The encoded string will be ~2 times larger than the original in terms of bytes.
+The encoded string will be twice as large as the original in terms of bytes.
 
 Additionally the crate provides a function to encode Python code and wrap the
 result in a decoder that decodes and executes it such that the result retains the

--- a/codec/README.md
+++ b/codec/README.md
@@ -25,13 +25,13 @@ Encode a string to a grapheme cluster with `zalgo_encode`:
 ```rust
 let s = "Zalgo";
 let encoded = zalgo_encode(s)?;
-assert_eq!(encoded, "É̺͇͌͏");
+assert_eq!(encoded, "̺͇́͌͏");
 ```
 
 Decode a grapheme cluster back into a string with `zalgo_decode`:
 
 ```rust
-let encoded = "É̺͇͌͏";
+let encoded = "̺͇́͌͏";
 let s = zalgo_decode(encoded)?;
 assert_eq!(s, "Zalgo");
 ```
@@ -42,10 +42,10 @@ various ways:
 ```rust
 let s = "Zalgo";
 let zstr = ZalgoString::new(s)?;
-assert_eq!(zstr, "É̺͇͌͏");
-assert_eq!(zstr.len(), 2 * s.len() + 1);
+assert_eq!(zstr, "̺͇́͌͏");
+assert_eq!(zstr.len(), 2 * s.len());
 assert_eq!(zstr.decoded_len(), s.len());
-assert_eq!(zstr.bytes().next(), Some(69));
+assert_eq!(zstr.bytes().next(), Some(204));
 assert_eq!(zstr.decoded_chars().next_back(), Some('o'));
 ```
 
@@ -54,7 +54,7 @@ We can execute zalgo encoded rust code with the macro `zalgo_embed!`:
 ```rust
 // This expands to the code
 // `fn add(x: i32, y: i32) -> i32 {x + y}`
-zalgo_embed!("E͎͉͙͉̞͉͙͆̀́̈́̈́̈̀̓̒̌̀̀̓̒̉̀̍̀̓̒̀͛̀̋̀͘̚̚͘͝");
+zalgo_embed!("͎͉͙͉̞͉͙͆̀́̈́̈́̈̀̓̒̌̀̀̓̒̉̀̍̀̓̒̀͛̀̋̀͘̚̚͘͝");
 
 // The `add` function is now available
 assert_eq!(add(10, 20), 30);
@@ -67,7 +67,7 @@ let x = 20;
 let y = -10;
 // This expands to the code 
 // `x + y`
-let z = zalgo_embed!("È͙̋̀͘");
+let z = zalgo_embed!("͙̀̋̀͘");
 assert_eq!(z, x + y);
 ```
 
@@ -75,7 +75,7 @@ We can also do the opposite of [`obfstr`](https://crates.io/crates/obfstr): obfu
 a string while coding and deobfuscate it during compile time
 
 ```rust
-let secret_string = zalgo_embed!("Ê̤͏͎͔͔͈͉͓͍̇̀͒́̈́̀̀ͅ͏͍́̂");
+let secret_string = zalgo_embed!("̤̂͏͎͔͔͈͉͓͍̇̀͒́̈́̀̀ͅ͏͍́̂");
 assert_eq!(secret_string, "Don't read this mom!");
 ```
 
@@ -89,7 +89,7 @@ encoded with the encoding function in this crate.
 <br>
 <br>
 <br>
-E̬͏͍͉͓͕͍͒̀͐̀̈́ͅ͏͌͏͓͉͔͍͔͒̀̀́̌̀̓ͅ͏͎͓͔͔͕͉͉͓͉͎͇͉͔͓̓͒̀́̈́͐̓̀͌̌̀̈́̀̈́ͅͅͅͅ͏͉͕͓͍̀ͅ͏͔͍̈́̀͐ͅ͏͉͎͉͉͕͎͔͕͔͒̀̓̈́̈́̀̀͌́͂͏͔͒̀̀̈́ͅͅ͏͌͏͍͇͎͉͒̀́́̀́͌ͅ<br>
+̬͏͍͉͓͕͍͒̀͐̀̈́ͅ͏͌͏͓͉͔͍͔͒̀̀́̌̀̓ͅ͏͎͓͔͔͕͉͉͓͉͎͇͉͔͓̓͒̀́̈́͐̓̀͌̌̀̈́̀̈́ͅͅͅͅ͏͉͕͓͍̀ͅ͏͔͍̈́̀͐ͅ͏͉͎͉͉͕͎͔͕͔͒̀̓̈́̈́̀̀͌́͂͏͔͒̀̀̈́ͅͅ͏͌͏͍͇͎͉͒̀́́̀́͌ͅ<br>
 <br>
 <br>
 <br>

--- a/codec/src/lib.rs
+++ b/codec/src/lib.rs
@@ -18,14 +18,14 @@
 //! # use zalgo_codec::{EncodeError, zalgo_encode};
 //! let s = "Zalgo";
 //! let encoded = zalgo_encode(s)?;
-//! assert_eq!(encoded, "É̺͇͌͏");
+//! assert_eq!(encoded, "̺͇́͌͏");
 //! # Ok::<(), EncodeError>(())
 //! ```
 //! Decode the grapheme cluster back into a string with [`zalgo_decode`]:
 //! ```
 //! # use zalgo_codec::{zalgo_decode, DecodeError};
 //! # extern crate alloc;
-//! let encoded = "É̺͇͌͏";
+//! let encoded = "̺͇́͌͏";
 //! let s = zalgo_decode(encoded)?;
 //! assert_eq!(s, "Zalgo");
 //! # Ok::<(), DecodeError>(())
@@ -34,11 +34,11 @@
 //! ```
 //! # use zalgo_codec::{EncodeError, ZalgoString};
 //! let s = "Zalgo";
-//! let zstr = ZalgoString::new(s)?;
-//! assert_eq!(zstr, "É̺͇͌͏");
-//! assert_eq!(zstr.len(), 2 * s.len() + 1);
+//! let zstr = ZalgoString::try_from(s)?;
+//! assert_eq!(zstr, "̺͇́͌͏");
+//! assert_eq!(zstr.len(), 2 * s.len());
 //! assert_eq!(zstr.decoded_len(), s.len());
-//! assert_eq!(zstr.bytes().next(), Some(69));
+//! assert_eq!(zstr.bytes().next(), Some(204));
 //! assert_eq!(zstr.decoded_chars().next_back(), Some('o'));
 //! # Ok::<(), EncodeError>(())
 //! ```
@@ -48,7 +48,7 @@
 //! # {
 //! # use zalgo_codec::zalgo_embed;
 //! // This grapheme cluster was made by encoding "add(x: i32, y: i32) -> i32 {x + y}"
-//! zalgo_embed!("E͎͉͙͉̞͉͙͆̀́̈́̈́̈̀̓̒̌̀̀̓̒̉̀̍̀̓̒̀͛̀̋̀͘̚̚͘͝");
+//! zalgo_embed!("͎͉͙͉̞͉͙͆̀́̈́̈́̈̀̓̒̌̀̀̓̒̉̀̍̀̓̒̀͛̀̋̀͘̚̚͘͝");
 //!
 //! // The `add` function is now available
 //! assert_eq!(add(10, 20), 30);
@@ -232,9 +232,9 @@ mod tests {
         let code = "fn add(x: i32, y: i32) -> i32 {x + y}";
 
         let encoded = zalgo_encode(code).unwrap();
-        assert_eq!(encoded, "E͎͉͙͉̞͉͙͆̀́̈́̈́̈̀̓̒̌̀̀̓̒̉̀̍̀̓̒̀͛̀̋̀͘̚̚͘͝");
+        assert_eq!(encoded, "͎͉͙͉̞͉͙͆̀́̈́̈́̈̀̓̒̌̀̀̓̒̉̀̍̀̓̒̀͛̀̋̀͘̚̚͘͝");
 
-        zalgo_embed!("E͎͉͙͉̞͉͙͆̀́̈́̈́̈̀̓̒̌̀̀̓̒̉̀̍̀̓̒̀͛̀̋̀͘̚̚͘͝");
+        zalgo_embed!("͎͉͙͉̞͉͙͆̀́̈́̈́̈̀̓̒̌̀̀̓̒̉̀̍̀̓̒̀͛̀̋̀͘̚̚͘͝");
 
         // Now the `add` function is available
         assert_eq!(add(10, 20), 30)
@@ -250,17 +250,17 @@ mod tests {
 
         let encoded = zalgo_encode(expr).unwrap();
 
-        assert_eq!(encoded, "È͙̋̀͘");
+        assert_eq!(encoded, "͙̀̋̀͘");
 
         // It works on expressions, too!
-        let z = zalgo_embed!("È͙̋̀͘");
+        let z = zalgo_embed!("͙̀̋̀͘");
         assert_eq!(z, x + y);
     }
 
     #[test]
     fn verify() {
         const TEST_STRING_1: &str = "the greatest adventure is going to bed";
-        let out_string = str::from_utf8(b"E\xcd\x94\xcd\x88\xcd\x85\xcc\x80\xcd\x87\xcd\x92\xcd\x85\xcd\x81\xcd\x94\xcd\x85\xcd\x93\xcd\x94\xcc\x80\xcd\x81\xcd\x84\xcd\x96\xcd\x85\xcd\x8e\xcd\x94\xcd\x95\xcd\x92\xcd\x85\xcc\x80\xcd\x89\xcd\x93\xcc\x80\xcd\x87\xcd\x8f\xcd\x89\xcd\x8e\xcd\x87\xcc\x80\xcd\x94\xcd\x8f\xcc\x80\xcd\x82\xcd\x85\xcd\x84").unwrap();
+        let out_string = str::from_utf8(b"\xcd\x94\xcd\x88\xcd\x85\xcc\x80\xcd\x87\xcd\x92\xcd\x85\xcd\x81\xcd\x94\xcd\x85\xcd\x93\xcd\x94\xcc\x80\xcd\x81\xcd\x84\xcd\x96\xcd\x85\xcd\x8e\xcd\x94\xcd\x95\xcd\x92\xcd\x85\xcc\x80\xcd\x89\xcd\x93\xcc\x80\xcd\x87\xcd\x8f\xcd\x89\xcd\x8e\xcd\x87\xcc\x80\xcd\x94\xcd\x8f\xcc\x80\xcd\x82\xcd\x85\xcd\x84").unwrap();
         assert_eq!(zalgo_encode(TEST_STRING_1).unwrap(), out_string);
 
         const TEST_STRING_2: &str =
@@ -287,7 +287,7 @@ mod tests {
 
     #[test]
     fn newlines() {
-        assert_eq!(&zalgo_encode("\n").unwrap(), "Eͯ",);
+        assert_eq!(&zalgo_encode("\n").unwrap(), "ͯ",);
         const TEST_STRING: &str = "The next sentence is true.\nThe previous sentence is false.";
         assert_eq!(
             zalgo_decode(&zalgo_encode(TEST_STRING).unwrap()).unwrap(),

--- a/common/CHANGELOG.md
+++ b/common/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 This document contains all changes to the crate since version 0.9.4.
 
+## 0.14.0
+
+- Change the format of the encoded string to remove the initial "E".
+ This lets the `new` function be `const` as it no longer has to allocate anything,
+ and the format becomes more straightforward.
+ This removes the functions that previously worked with only the combining characters,
+ like `as_combining_chars()` which now has its functionality subsumed by `as_str()`.
+
 ## 0.13.4
 
 - Update dependencies.

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zalgo-codec-common"
 authors = ["Johanna Sörngård <jsorngard@gmail.com>", "Scott Conner"]
-version = "0.13.4"
+version = "0.14.0"
 edition = "2021"
 keywords = ["unicode", "obfuscation", "encoding", "zalgo"]
 categories = ["encoding", "text-processing"]

--- a/common/README.md
+++ b/common/README.md
@@ -15,13 +15,13 @@ Encode a string to a grapheme cluster with `zalgo_encode`:
 ```rust
 let s = "Zalgo";
 let encoded = zalgo_encode(s)?;
-assert_eq!(encoded, "É̺͇͌͏");
+assert_eq!(encoded, "̺͇́͌͏");
 ```
 
 Decode a grapheme cluster back into a string:
 
 ```rust
-let encoded = "É̺͇͌͏";
+let encoded = "̺͇́͌͏";
 let s = zalgo_decode(encoded)?;
 assert_eq!(s, "Zalgo");
 ```
@@ -32,10 +32,10 @@ various ways:
 ```rust
 let s = "Zalgo";
 let zstr = ZalgoString::new(s)?;
-assert_eq!(zstr, "É̺͇͌͏");
-assert_eq!(zstr.len(), 2 * s.len() + 1);
+assert_eq!(zstr, "̺͇́͌͏");
+assert_eq!(zstr.len(), 2 * s.len());
 assert_eq!(zstr.decoded_len(), s.len());
-assert_eq!(zstr.bytes().next(), Some(69));
+assert_eq!(zstr.bytes().next(), Some(204));
 assert_eq!(zstr.decoded_chars().next_back(), Some('o'));
 ```
 

--- a/common/benches/codec_bench.rs
+++ b/common/benches/codec_bench.rs
@@ -42,7 +42,7 @@ fn bench_codec(c: &mut Criterion) {
 
     c.bench_function("ZalgoString", |b| {
         b.iter(|| {
-            let zs = black_box(ZalgoString::new(&string)).unwrap();
+            let zs = black_box(ZalgoString::try_from(string.as_str())).unwrap();
             black_box(zs.into_decoded_string())
         })
     });

--- a/common/src/error.rs
+++ b/common/src/error.rs
@@ -1,6 +1,6 @@
 //! Contains the definition of the error type used by the encoding functions in the crate.
 
-use core::{fmt, str::Utf8Error};
+use core::fmt;
 
 #[cfg(feature = "std")]
 use std::backtrace::Backtrace;
@@ -147,27 +147,18 @@ impl core::error::Error for EncodeError {}
 /// The error returned by [`zalgo_decode`](super::zalgo_decode) if a string can not be decoded.
 #[derive(Debug)]
 pub struct DecodeError {
-    kind: DecodeErrorKind,
+    source_error: FromUtf8Error,
     #[cfg(feature = "std")]
     backtrace: Backtrace,
 }
 
 impl DecodeError {
-    pub(crate) fn new(possible_error: Option<FromUtf8Error>) -> Self {
+    pub(crate) fn new(source_error: FromUtf8Error) -> Self {
         Self {
             #[cfg(feature = "std")]
             backtrace: Backtrace::capture(),
-            kind: match possible_error {
-                Some(e) => DecodeErrorKind::InvalidUtf8(e),
-                None => DecodeErrorKind::EmptyInput,
-            },
+            source_error,
         }
-    }
-
-    /// Returns whether the error happened because the given string was empty,
-    /// and not because the decoding resulted in invalid UTF-8.
-    pub fn cause_was_empty_string(&self) -> bool {
-        matches!(self.kind, DecodeErrorKind::EmptyInput)
     }
 
     #[cfg(feature = "std")]
@@ -179,55 +170,25 @@ impl DecodeError {
         &self.backtrace
     }
 
-    /// If the error happened because the decoding resulted in invalid UTF-8,
-    /// this function returns the [`Utf8Error`] that was created in the process.
-    pub fn to_utf8_error(&self) -> Option<Utf8Error> {
-        match &self.kind {
-            DecodeErrorKind::InvalidUtf8(e) => Some(e.utf8_error()),
-            DecodeErrorKind::EmptyInput => None,
-        }
-    }
-
-    /// If the error happened because the decoding resulted in invalid UTF-8,
-    /// this function converts this error into the [`FromUtf8Error`] that was created in the process.
-    pub fn into_from_utf8_error(self) -> Option<FromUtf8Error> {
-        match self.kind {
-            DecodeErrorKind::InvalidUtf8(e) => Some(e),
-            DecodeErrorKind::EmptyInput => None,
-        }
+    /// This function converts this error into the [`FromUtf8Error`] that caused this decoding error.
+    pub fn into_from_utf8_error(self) -> FromUtf8Error {
+        self.source_error
     }
 }
 
 impl fmt::Display for DecodeError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "could not decode the string because {}", self.kind)
+        write!(
+            f,
+            "could not decode the string because {}",
+            self.source_error
+        )
     }
 }
 
 impl core::error::Error for DecodeError {
     fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
-        match self.kind {
-            DecodeErrorKind::InvalidUtf8(ref e) => Some(e),
-            DecodeErrorKind::EmptyInput => None,
-        }
-    }
-}
-
-/// The kind of error the caused the decoding failure.
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum DecodeErrorKind {
-    /// The given string was empty.
-    EmptyInput,
-    /// Decoding the string resulted in invalid UTF-8.
-    InvalidUtf8(FromUtf8Error),
-}
-
-impl fmt::Display for DecodeErrorKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::EmptyInput => write!(f, "the string was empty"),
-            Self::InvalidUtf8(e) => write!(f, "decoding resulted in invalid utf8: {e}"),
-        }
+        Some(&self.source_error)
     }
 }
 
@@ -247,17 +208,8 @@ mod test {
 
     #[test]
     fn test_decode_error() {
-        let err = DecodeError::new(None);
-        assert_eq!(err.to_utf8_error(), None);
-        assert!(err.cause_was_empty_string());
-        assert_eq!(err.into_from_utf8_error(), None);
-        let err = DecodeError::new(String::from_utf8(vec![255, 255, 255, 255, 255, 255]).err());
-        assert_eq!(err.to_utf8_error().unwrap().error_len(), Some(1));
-        assert_eq!(err.to_utf8_error().unwrap().valid_up_to(), 0);
-        assert!(!err.cause_was_empty_string());
-        assert_eq!(
-            err.into_from_utf8_error().unwrap().into_bytes(),
-            vec![255; 6]
-        );
+        let err =
+            DecodeError::new(String::from_utf8(vec![255, 255, 255, 255, 255, 255]).unwrap_err());
+        assert_eq!(err.into_from_utf8_error().into_bytes(), vec![255; 6]);
     }
 }

--- a/common/src/error.rs
+++ b/common/src/error.rs
@@ -8,7 +8,7 @@ use std::backtrace::Backtrace;
 use alloc::string::FromUtf8Error;
 
 #[derive(Debug)]
-/// The error returned by [`zalgo_encode`](crate::zalgo_encode), [`ZalgoString::new`](crate::ZalgoString::new), and [`zalgo_wrap_python`](crate::zalgo_wrap_python)
+/// The error returned by [`zalgo_encode`](crate::zalgo_encode), [`ZalgoString::try_from`](crate::ZalgoString::try_from), and [`zalgo_wrap_python`](crate::zalgo_wrap_python)
 /// if they encounter a byte they can not encode.
 pub struct EncodeError {
     unencodable_character: char,

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -372,7 +372,6 @@ const fn decode_byte_pair(odd: u8, even: u8) -> u8 {
 ///     Err(('€', 1, 22)),
 /// );
 /// ```
-#[must_use = "the function returns a new value and does not modify the input"]
 pub fn zalgo_wrap_python(python: &str) -> Result<String, EncodeError> {
     let encoded_string = zalgo_encode(python)?;
     Ok(format!("b='{encoded_string}'.encode();exec(''.join(chr(((h<<6&64|c&63)+22)%133+10)for h,c in zip(b[0::2],b[1::2])))"))

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -13,39 +13,43 @@
 //! # use zalgo_codec_common::{EncodeError, zalgo_encode};
 //! let s = "Zalgo";
 //! let encoded = zalgo_encode(s)?;
-//! assert_eq!(encoded, "É̺͇͌͏");
+//! assert_eq!(encoded, "̺͇́͌͏");
 //! # Ok::<(), EncodeError>(())
 //! ```
 //! Decode a grapheme cluster back into a string:
 //! ```
 //! # use zalgo_codec_common::{zalgo_decode, DecodeError};
-//! let encoded = "É̺͇͌͏";
+//! let encoded = "̺͇́͌͏";
 //! let s = zalgo_decode(encoded)?;
 //! assert_eq!(s, "Zalgo");
 //! # Ok::<(), DecodeError>(())
 //! ```
+//!
 //! The [`ZalgoString`] type can be used to encode a string and handle the result in various ways:
+//!
 //! ```
 //! # use zalgo_codec_common::{ZalgoString, EncodeError};
+//! # fn main() -> Result<(), EncodeError> {
 //! let s = "Zalgo";
-//! let zstr = ZalgoString::new(s)?;
+//! let zstr = ZalgoString::try_from(s)?;
 //!
 //! // Implements PartialEq with common string types
-//! assert_eq!(zstr, "É̺͇͌͏");
+//! assert_eq!(zstr, "̺͇́͌͏");
 //!
 //! // Utility functions
-//! assert_eq!(zstr.len(), 2 * s.len() + 1);
+//! assert_eq!(zstr.len(), 2 * s.len());
 //! assert_eq!(zstr.decoded_len(), s.len());
 //!
 //! // Iterate over bytes and chars, in both encoded and decoded form
-//! assert_eq!(zstr.bytes().next(), Some(69));
+//! assert_eq!(zstr.bytes().next(), Some(204));
 //! assert_eq!(zstr.decoded_bytes().nth_back(2), Some(b'l'));
-//! assert_eq!(zstr.chars().nth(1), Some('\u{33a}'));
+//! assert_eq!(zstr.chars().nth(1), Some('\u{341}'));
 //! assert_eq!(zstr.decoded_chars().next_back(), Some('o'));
 //!
 //! // Decode inplace
 //! assert_eq!(zstr.into_decoded_string(), "Zalgo");
-//! # Ok::<(), EncodeError>(())
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! # Feature flags
@@ -210,7 +214,7 @@ pub use zalgo_string::ZalgoString;
 /// Basic usage:
 /// ```
 /// # use zalgo_codec_common::{EncodeError, zalgo_encode};
-/// assert_eq!(zalgo_encode("Zalgo")?, "É̺͇͌͏");
+/// assert_eq!(zalgo_encode("Zalgo")?, "̺͇́͌͏");
 /// # Ok::<(), EncodeError>(())
 /// ```
 /// Can not encode non-ASCII characters or ASCII control characters except newlines:
@@ -232,8 +236,7 @@ pub fn zalgo_encode(string: &str) -> Result<String, EncodeError> {
 
     // Every byte in the input will encode to two bytes. The extra byte is for the initial letter
     // which is there in order for the output to be displayable in an intuitive way.
-    let mut result = Vec::with_capacity(2 * string.len() + 1);
-    result.push(b'E');
+    let mut result = Vec::with_capacity(2 * string.len());
 
     for (i, batch) in string.as_bytes().chunks(BATCH_SIZE).enumerate() {
         let mut buffer = [0; 2 * BATCH_SIZE];
@@ -289,29 +292,28 @@ pub fn zalgo_encode(string: &str) -> Result<String, EncodeError> {
 /// Basic usage:
 /// ```
 /// # use zalgo_codec_common::{zalgo_decode, DecodeError};
-/// assert_eq!(zalgo_decode("É̺͇͌͏")?, "Zalgo");
+/// assert_eq!(zalgo_decode("̺͇́͌͏")?, "Zalgo");
 /// # Ok::<(), DecodeError>(())
 /// ```
 /// Decoding arbitrary strings that were not produced by [`zalgo_encode`] will most likely lead to errors:
 /// ```
 /// # use zalgo_codec_common::zalgo_decode;
-/// assert!(zalgo_decode("Zalgo").is_err());
+/// assert!(zalgo_decode("Blorbo goes to space").is_err());
 /// ```
 /// If it doesn't the results are not meaningful:
 /// ```
 /// # use zalgo_codec_common::{zalgo_decode, DecodeError};
-/// assert_eq!(zalgo_decode("awö")?, "c");
+/// assert_eq!(zalgo_decode("awö")?, "\u{12}\u{11}");
 /// # Ok::<(), DecodeError>(())
 /// ```
-#[must_use = "the function returns a new value and does not modify the input"]
 pub fn zalgo_decode(encoded: &str) -> Result<String, DecodeError> {
     if encoded.is_empty() {
         return Err(DecodeError::new(None));
     }
-    let mut res = vec![0; (encoded.len() - 1) / 2];
+    let mut res = vec![0; encoded.len() / 2];
     let bytes = encoded.as_bytes();
 
-    for (write, read) in (1..encoded.len()).step_by(2).enumerate() {
+    for (write, read) in (0..encoded.len()).step_by(2).enumerate() {
         match bytes.get(read + 1) {
             Some(next) => res[write] = decode_byte_pair(bytes[read], *next),
             None => break,
@@ -340,7 +342,7 @@ const fn decode_byte_pair(odd: u8, even: u8) -> u8 {
 /// let py_hello_world_enc = zalgo_wrap_python(py_hello_world)?;
 /// assert_eq!(
 ///     py_hello_world_enc,
-///     "b='Ę͉͎͔͐͒̈̂͌͌ͅ͏̌̀͗͏͒͌̈́́̂̉ͯ'.encode();exec(''.join(chr(((h<<6&64|c&63)+22)%133+10)for h,c in zip(b[1::2],b[2::2])))",
+///     "b='̨͉͎͔͐͒̈̂͌͌ͅ͏̌̀͗͏͒͌̈́́̂̉ͯ'.encode();exec(''.join(chr(((h<<6&64|c&63)+22)%133+10)for h,c in zip(b[0::2],b[1::2])))",
 /// );
 /// # Ok::<(), EncodeError>(())
 /// ```
@@ -374,7 +376,7 @@ const fn decode_byte_pair(odd: u8, even: u8) -> u8 {
 #[must_use = "the function returns a new value and does not modify the input"]
 pub fn zalgo_wrap_python(python: &str) -> Result<String, EncodeError> {
     let encoded_string = zalgo_encode(python)?;
-    Ok(format!("b='{encoded_string}'.encode();exec(''.join(chr(((h<<6&64|c&63)+22)%133+10)for h,c in zip(b[1::2],b[2::2])))"))
+    Ok(format!("b='{encoded_string}'.encode();exec(''.join(chr(((h<<6&64|c&63)+22)%133+10)for h,c in zip(b[0::2],b[1::2])))"))
 }
 
 #[cfg(test)]
@@ -394,179 +396,179 @@ mod test {
 
     #[test]
     fn verify_conversion_table() {
-        assert_eq!(zalgo_encode("A").unwrap(), "E\u{321}");
-        assert_eq!(zalgo_decode("E\u{321}").unwrap(), "A");
-        assert_eq!(zalgo_encode("B").unwrap(), "E\u{322}");
-        assert_eq!(zalgo_decode("E\u{322}").unwrap(), "B");
-        assert_eq!(zalgo_encode("C").unwrap(), "E\u{323}");
-        assert_eq!(zalgo_decode("E\u{323}").unwrap(), "C");
-        assert_eq!(zalgo_encode("D").unwrap(), "E\u{324}");
-        assert_eq!(zalgo_decode("E\u{324}").unwrap(), "D");
-        assert_eq!(zalgo_encode("E").unwrap(), "E\u{325}");
-        assert_eq!(zalgo_decode("E\u{325}").unwrap(), "E");
-        assert_eq!(zalgo_encode("F").unwrap(), "E\u{326}");
-        assert_eq!(zalgo_decode("E\u{326}").unwrap(), "F");
-        assert_eq!(zalgo_encode("G").unwrap(), "E\u{327}");
-        assert_eq!(zalgo_decode("E\u{327}").unwrap(), "G");
-        assert_eq!(zalgo_encode("H").unwrap(), "E\u{328}");
-        assert_eq!(zalgo_decode("E\u{328}").unwrap(), "H");
-        assert_eq!(zalgo_encode("I").unwrap(), "E\u{329}");
-        assert_eq!(zalgo_decode("E\u{329}").unwrap(), "I");
-        assert_eq!(zalgo_encode("J").unwrap(), "E\u{32a}");
-        assert_eq!(zalgo_decode("E\u{32a}").unwrap(), "J");
-        assert_eq!(zalgo_encode("K").unwrap(), "E\u{32b}");
-        assert_eq!(zalgo_decode("E\u{32b}").unwrap(), "K");
-        assert_eq!(zalgo_encode("L").unwrap(), "E\u{32c}");
-        assert_eq!(zalgo_decode("E\u{32c}").unwrap(), "L");
-        assert_eq!(zalgo_encode("M").unwrap(), "E\u{32d}");
-        assert_eq!(zalgo_decode("E\u{32d}").unwrap(), "M");
-        assert_eq!(zalgo_encode("N").unwrap(), "E\u{32e}");
-        assert_eq!(zalgo_decode("E\u{32e}").unwrap(), "N");
-        assert_eq!(zalgo_encode("O").unwrap(), "E\u{32f}");
-        assert_eq!(zalgo_decode("E\u{32f}").unwrap(), "O");
-        assert_eq!(zalgo_encode("P").unwrap(), "E\u{330}");
-        assert_eq!(zalgo_decode("E\u{330}").unwrap(), "P");
-        assert_eq!(zalgo_encode("Q").unwrap(), "E\u{331}");
-        assert_eq!(zalgo_decode("E\u{331}").unwrap(), "Q");
-        assert_eq!(zalgo_encode("R").unwrap(), "E\u{332}");
-        assert_eq!(zalgo_decode("E\u{332}").unwrap(), "R");
-        assert_eq!(zalgo_encode("S").unwrap(), "E\u{333}");
-        assert_eq!(zalgo_decode("E\u{333}").unwrap(), "S");
-        assert_eq!(zalgo_encode("T").unwrap(), "E\u{334}");
-        assert_eq!(zalgo_decode("E\u{334}").unwrap(), "T");
-        assert_eq!(zalgo_encode("U").unwrap(), "E\u{335}");
-        assert_eq!(zalgo_decode("E\u{335}").unwrap(), "U");
-        assert_eq!(zalgo_encode("V").unwrap(), "E\u{336}");
-        assert_eq!(zalgo_decode("E\u{336}").unwrap(), "V");
-        assert_eq!(zalgo_encode("W").unwrap(), "E\u{337}");
-        assert_eq!(zalgo_decode("E\u{337}").unwrap(), "W");
-        assert_eq!(zalgo_encode("X").unwrap(), "E\u{338}");
-        assert_eq!(zalgo_decode("E\u{338}").unwrap(), "X");
-        assert_eq!(zalgo_encode("Y").unwrap(), "E\u{339}");
-        assert_eq!(zalgo_decode("E\u{339}").unwrap(), "Y");
-        assert_eq!(zalgo_encode("Z").unwrap(), "E\u{33a}");
-        assert_eq!(zalgo_decode("E\u{33a}").unwrap(), "Z");
-        assert_eq!(zalgo_encode("a").unwrap(), "E\u{341}");
-        assert_eq!(zalgo_decode("E\u{341}").unwrap(), "a");
-        assert_eq!(zalgo_encode("b").unwrap(), "E\u{342}");
-        assert_eq!(zalgo_decode("E\u{342}").unwrap(), "b");
-        assert_eq!(zalgo_encode("c").unwrap(), "E\u{343}");
-        assert_eq!(zalgo_decode("E\u{343}").unwrap(), "c");
-        assert_eq!(zalgo_encode("d").unwrap(), "E\u{344}");
-        assert_eq!(zalgo_decode("E\u{344}").unwrap(), "d");
-        assert_eq!(zalgo_encode("e").unwrap(), "E\u{345}");
-        assert_eq!(zalgo_decode("E\u{345}").unwrap(), "e");
-        assert_eq!(zalgo_encode("f").unwrap(), "E\u{346}");
-        assert_eq!(zalgo_decode("E\u{346}").unwrap(), "f");
-        assert_eq!(zalgo_encode("g").unwrap(), "E\u{347}");
-        assert_eq!(zalgo_decode("E\u{347}").unwrap(), "g");
-        assert_eq!(zalgo_encode("h").unwrap(), "E\u{348}");
-        assert_eq!(zalgo_decode("E\u{348}").unwrap(), "h");
-        assert_eq!(zalgo_encode("i").unwrap(), "E\u{349}");
-        assert_eq!(zalgo_decode("E\u{349}").unwrap(), "i");
-        assert_eq!(zalgo_encode("j").unwrap(), "E\u{34a}");
-        assert_eq!(zalgo_decode("E\u{34a}").unwrap(), "j");
-        assert_eq!(zalgo_encode("k").unwrap(), "E\u{34b}");
-        assert_eq!(zalgo_decode("E\u{34b}").unwrap(), "k");
-        assert_eq!(zalgo_encode("l").unwrap(), "E\u{34c}");
-        assert_eq!(zalgo_decode("E\u{34c}").unwrap(), "l");
-        assert_eq!(zalgo_encode("m").unwrap(), "E\u{34d}");
-        assert_eq!(zalgo_decode("E\u{34d}").unwrap(), "m");
-        assert_eq!(zalgo_encode("n").unwrap(), "E\u{34e}");
-        assert_eq!(zalgo_decode("E\u{34e}").unwrap(), "n");
-        assert_eq!(zalgo_encode("o").unwrap(), "E\u{34f}");
-        assert_eq!(zalgo_decode("E\u{34f}").unwrap(), "o");
-        assert_eq!(zalgo_encode("p").unwrap(), "E\u{350}");
-        assert_eq!(zalgo_decode("E\u{350}").unwrap(), "p");
-        assert_eq!(zalgo_encode("q").unwrap(), "E\u{351}");
-        assert_eq!(zalgo_decode("E\u{351}").unwrap(), "q");
-        assert_eq!(zalgo_encode("r").unwrap(), "E\u{352}");
-        assert_eq!(zalgo_decode("E\u{352}").unwrap(), "r");
-        assert_eq!(zalgo_encode("s").unwrap(), "E\u{353}");
-        assert_eq!(zalgo_decode("E\u{353}").unwrap(), "s");
-        assert_eq!(zalgo_encode("t").unwrap(), "E\u{354}");
-        assert_eq!(zalgo_decode("E\u{354}").unwrap(), "t");
-        assert_eq!(zalgo_encode("u").unwrap(), "E\u{355}");
-        assert_eq!(zalgo_decode("E\u{355}").unwrap(), "u");
-        assert_eq!(zalgo_encode("v").unwrap(), "E\u{356}");
-        assert_eq!(zalgo_decode("E\u{356}").unwrap(), "v");
-        assert_eq!(zalgo_encode("w").unwrap(), "E\u{357}");
-        assert_eq!(zalgo_decode("E\u{357}").unwrap(), "w");
-        assert_eq!(zalgo_encode("x").unwrap(), "E\u{358}");
-        assert_eq!(zalgo_decode("E\u{358}").unwrap(), "x");
-        assert_eq!(zalgo_encode("y").unwrap(), "E\u{359}");
-        assert_eq!(zalgo_decode("E\u{359}").unwrap(), "y");
-        assert_eq!(zalgo_encode("z").unwrap(), "E\u{35a}");
-        assert_eq!(zalgo_decode("E\u{35a}").unwrap(), "z");
-        assert_eq!(zalgo_encode("1").unwrap(), "E\u{311}");
-        assert_eq!(zalgo_decode("E\u{311}").unwrap(), "1");
-        assert_eq!(zalgo_encode("2").unwrap(), "E\u{312}");
-        assert_eq!(zalgo_decode("E\u{312}").unwrap(), "2");
-        assert_eq!(zalgo_encode("3").unwrap(), "E\u{313}");
-        assert_eq!(zalgo_decode("E\u{313}").unwrap(), "3");
-        assert_eq!(zalgo_encode("4").unwrap(), "E\u{314}");
-        assert_eq!(zalgo_decode("E\u{314}").unwrap(), "4");
-        assert_eq!(zalgo_encode("5").unwrap(), "E\u{315}");
-        assert_eq!(zalgo_decode("E\u{315}").unwrap(), "5");
-        assert_eq!(zalgo_encode("6").unwrap(), "E\u{316}");
-        assert_eq!(zalgo_decode("E\u{316}").unwrap(), "6");
-        assert_eq!(zalgo_encode("7").unwrap(), "E\u{317}");
-        assert_eq!(zalgo_decode("E\u{317}").unwrap(), "7");
-        assert_eq!(zalgo_encode("8").unwrap(), "E\u{318}");
-        assert_eq!(zalgo_decode("E\u{318}").unwrap(), "8");
-        assert_eq!(zalgo_encode("9").unwrap(), "E\u{319}");
-        assert_eq!(zalgo_decode("E\u{319}").unwrap(), "9");
-        assert_eq!(zalgo_encode("0").unwrap(), "E\u{310}");
-        assert_eq!(zalgo_decode("E\u{310}").unwrap(), "0");
-        assert_eq!(zalgo_encode(" ").unwrap(), "E\u{300}");
-        assert_eq!(zalgo_decode("E\u{300}").unwrap(), " ");
-        assert_eq!(zalgo_encode("!").unwrap(), "E\u{301}");
-        assert_eq!(zalgo_decode("E\u{301}").unwrap(), "!");
-        assert_eq!(zalgo_encode("\"").unwrap(), "E\u{302}");
-        assert_eq!(zalgo_decode("E\u{302}").unwrap(), "\"");
-        assert_eq!(zalgo_encode("#").unwrap(), "E\u{303}");
-        assert_eq!(zalgo_decode("E\u{303}").unwrap(), "#");
-        assert_eq!(zalgo_encode("$").unwrap(), "E\u{304}");
-        assert_eq!(zalgo_decode("E\u{304}").unwrap(), "$");
-        assert_eq!(zalgo_encode("%").unwrap(), "E\u{305}");
-        assert_eq!(zalgo_decode("E\u{305}").unwrap(), "%");
-        assert_eq!(zalgo_encode("&").unwrap(), "E\u{306}");
-        assert_eq!(zalgo_decode("E\u{306}").unwrap(), "&");
-        assert_eq!(zalgo_encode("'").unwrap(), "E\u{307}");
-        assert_eq!(zalgo_decode("E\u{307}").unwrap(), "'");
-        assert_eq!(zalgo_encode("(").unwrap(), "E\u{308}");
-        assert_eq!(zalgo_decode("E\u{308}").unwrap(), "(");
-        assert_eq!(zalgo_encode(")").unwrap(), "E\u{309}");
-        assert_eq!(zalgo_decode("E\u{309}").unwrap(), ")");
-        assert_eq!(zalgo_encode("*").unwrap(), "E\u{30a}");
-        assert_eq!(zalgo_decode("E\u{30a}").unwrap(), "*");
-        assert_eq!(zalgo_encode("+").unwrap(), "E\u{30b}");
-        assert_eq!(zalgo_decode("E\u{30b}").unwrap(), "+");
-        assert_eq!(zalgo_encode(",").unwrap(), "E\u{30c}");
-        assert_eq!(zalgo_decode("E\u{30c}").unwrap(), ",");
-        assert_eq!(zalgo_encode("-").unwrap(), "E\u{30d}");
-        assert_eq!(zalgo_decode("E\u{30d}").unwrap(), "-");
-        assert_eq!(zalgo_encode("\\").unwrap(), "E\u{33c}");
-        assert_eq!(zalgo_decode("E\u{33c}").unwrap(), "\\");
-        assert_eq!(zalgo_encode(".").unwrap(), "E\u{30e}");
-        assert_eq!(zalgo_decode("E\u{30e}").unwrap(), ".");
-        assert_eq!(zalgo_encode("/").unwrap(), "E\u{30f}");
-        assert_eq!(zalgo_decode("E\u{30f}").unwrap(), "/");
-        assert_eq!(zalgo_encode(":").unwrap(), "E\u{31a}");
-        assert_eq!(zalgo_decode("E\u{31a}").unwrap(), ":");
-        assert_eq!(zalgo_encode(";").unwrap(), "E\u{31b}");
-        assert_eq!(zalgo_decode("E\u{31b}").unwrap(), ";");
-        assert_eq!(zalgo_encode("<").unwrap(), "E\u{31c}");
-        assert_eq!(zalgo_decode("E\u{31c}").unwrap(), "<");
-        assert_eq!(zalgo_encode("=").unwrap(), "E\u{31d}");
-        assert_eq!(zalgo_decode("E\u{31d}").unwrap(), "=");
-        assert_eq!(zalgo_encode(">").unwrap(), "E\u{31e}");
-        assert_eq!(zalgo_decode("E\u{31e}").unwrap(), ">");
-        assert_eq!(zalgo_encode("?").unwrap(), "E\u{31f}");
-        assert_eq!(zalgo_decode("E\u{31f}").unwrap(), "?");
-        assert_eq!(zalgo_encode("@").unwrap(), "E\u{320}");
-        assert_eq!(zalgo_decode("E\u{320}").unwrap(), "@");
-        assert_eq!(zalgo_encode("\n").unwrap(), "E\u{36f}");
-        assert_eq!(zalgo_decode("E\u{36f}").unwrap(), "\n");
+        assert_eq!(zalgo_encode("A").unwrap(), "\u{321}");
+        assert_eq!(zalgo_decode("\u{321}").unwrap(), "A");
+        assert_eq!(zalgo_encode("B").unwrap(), "\u{322}");
+        assert_eq!(zalgo_decode("\u{322}").unwrap(), "B");
+        assert_eq!(zalgo_encode("C").unwrap(), "\u{323}");
+        assert_eq!(zalgo_decode("\u{323}").unwrap(), "C");
+        assert_eq!(zalgo_encode("D").unwrap(), "\u{324}");
+        assert_eq!(zalgo_decode("\u{324}").unwrap(), "D");
+        assert_eq!(zalgo_encode("E").unwrap(), "\u{325}");
+        assert_eq!(zalgo_decode("\u{325}").unwrap(), "E");
+        assert_eq!(zalgo_encode("F").unwrap(), "\u{326}");
+        assert_eq!(zalgo_decode("\u{326}").unwrap(), "F");
+        assert_eq!(zalgo_encode("G").unwrap(), "\u{327}");
+        assert_eq!(zalgo_decode("\u{327}").unwrap(), "G");
+        assert_eq!(zalgo_encode("H").unwrap(), "\u{328}");
+        assert_eq!(zalgo_decode("\u{328}").unwrap(), "H");
+        assert_eq!(zalgo_encode("I").unwrap(), "\u{329}");
+        assert_eq!(zalgo_decode("\u{329}").unwrap(), "I");
+        assert_eq!(zalgo_encode("J").unwrap(), "\u{32a}");
+        assert_eq!(zalgo_decode("\u{32a}").unwrap(), "J");
+        assert_eq!(zalgo_encode("K").unwrap(), "\u{32b}");
+        assert_eq!(zalgo_decode("\u{32b}").unwrap(), "K");
+        assert_eq!(zalgo_encode("L").unwrap(), "\u{32c}");
+        assert_eq!(zalgo_decode("\u{32c}").unwrap(), "L");
+        assert_eq!(zalgo_encode("M").unwrap(), "\u{32d}");
+        assert_eq!(zalgo_decode("\u{32d}").unwrap(), "M");
+        assert_eq!(zalgo_encode("N").unwrap(), "\u{32e}");
+        assert_eq!(zalgo_decode("\u{32e}").unwrap(), "N");
+        assert_eq!(zalgo_encode("O").unwrap(), "\u{32f}");
+        assert_eq!(zalgo_decode("\u{32f}").unwrap(), "O");
+        assert_eq!(zalgo_encode("P").unwrap(), "\u{330}");
+        assert_eq!(zalgo_decode("\u{330}").unwrap(), "P");
+        assert_eq!(zalgo_encode("Q").unwrap(), "\u{331}");
+        assert_eq!(zalgo_decode("\u{331}").unwrap(), "Q");
+        assert_eq!(zalgo_encode("R").unwrap(), "\u{332}");
+        assert_eq!(zalgo_decode("\u{332}").unwrap(), "R");
+        assert_eq!(zalgo_encode("S").unwrap(), "\u{333}");
+        assert_eq!(zalgo_decode("\u{333}").unwrap(), "S");
+        assert_eq!(zalgo_encode("T").unwrap(), "\u{334}");
+        assert_eq!(zalgo_decode("\u{334}").unwrap(), "T");
+        assert_eq!(zalgo_encode("U").unwrap(), "\u{335}");
+        assert_eq!(zalgo_decode("\u{335}").unwrap(), "U");
+        assert_eq!(zalgo_encode("V").unwrap(), "\u{336}");
+        assert_eq!(zalgo_decode("\u{336}").unwrap(), "V");
+        assert_eq!(zalgo_encode("W").unwrap(), "\u{337}");
+        assert_eq!(zalgo_decode("\u{337}").unwrap(), "W");
+        assert_eq!(zalgo_encode("X").unwrap(), "\u{338}");
+        assert_eq!(zalgo_decode("\u{338}").unwrap(), "X");
+        assert_eq!(zalgo_encode("Y").unwrap(), "\u{339}");
+        assert_eq!(zalgo_decode("\u{339}").unwrap(), "Y");
+        assert_eq!(zalgo_encode("Z").unwrap(), "\u{33a}");
+        assert_eq!(zalgo_decode("\u{33a}").unwrap(), "Z");
+        assert_eq!(zalgo_encode("a").unwrap(), "\u{341}");
+        assert_eq!(zalgo_decode("\u{341}").unwrap(), "a");
+        assert_eq!(zalgo_encode("b").unwrap(), "\u{342}");
+        assert_eq!(zalgo_decode("\u{342}").unwrap(), "b");
+        assert_eq!(zalgo_encode("c").unwrap(), "\u{343}");
+        assert_eq!(zalgo_decode("\u{343}").unwrap(), "c");
+        assert_eq!(zalgo_encode("d").unwrap(), "\u{344}");
+        assert_eq!(zalgo_decode("\u{344}").unwrap(), "d");
+        assert_eq!(zalgo_encode("e").unwrap(), "\u{345}");
+        assert_eq!(zalgo_decode("\u{345}").unwrap(), "e");
+        assert_eq!(zalgo_encode("f").unwrap(), "\u{346}");
+        assert_eq!(zalgo_decode("\u{346}").unwrap(), "f");
+        assert_eq!(zalgo_encode("g").unwrap(), "\u{347}");
+        assert_eq!(zalgo_decode("\u{347}").unwrap(), "g");
+        assert_eq!(zalgo_encode("h").unwrap(), "\u{348}");
+        assert_eq!(zalgo_decode("\u{348}").unwrap(), "h");
+        assert_eq!(zalgo_encode("i").unwrap(), "\u{349}");
+        assert_eq!(zalgo_decode("\u{349}").unwrap(), "i");
+        assert_eq!(zalgo_encode("j").unwrap(), "\u{34a}");
+        assert_eq!(zalgo_decode("\u{34a}").unwrap(), "j");
+        assert_eq!(zalgo_encode("k").unwrap(), "\u{34b}");
+        assert_eq!(zalgo_decode("\u{34b}").unwrap(), "k");
+        assert_eq!(zalgo_encode("l").unwrap(), "\u{34c}");
+        assert_eq!(zalgo_decode("\u{34c}").unwrap(), "l");
+        assert_eq!(zalgo_encode("m").unwrap(), "\u{34d}");
+        assert_eq!(zalgo_decode("\u{34d}").unwrap(), "m");
+        assert_eq!(zalgo_encode("n").unwrap(), "\u{34e}");
+        assert_eq!(zalgo_decode("\u{34e}").unwrap(), "n");
+        assert_eq!(zalgo_encode("o").unwrap(), "\u{34f}");
+        assert_eq!(zalgo_decode("\u{34f}").unwrap(), "o");
+        assert_eq!(zalgo_encode("p").unwrap(), "\u{350}");
+        assert_eq!(zalgo_decode("\u{350}").unwrap(), "p");
+        assert_eq!(zalgo_encode("q").unwrap(), "\u{351}");
+        assert_eq!(zalgo_decode("\u{351}").unwrap(), "q");
+        assert_eq!(zalgo_encode("r").unwrap(), "\u{352}");
+        assert_eq!(zalgo_decode("\u{352}").unwrap(), "r");
+        assert_eq!(zalgo_encode("s").unwrap(), "\u{353}");
+        assert_eq!(zalgo_decode("\u{353}").unwrap(), "s");
+        assert_eq!(zalgo_encode("t").unwrap(), "\u{354}");
+        assert_eq!(zalgo_decode("\u{354}").unwrap(), "t");
+        assert_eq!(zalgo_encode("u").unwrap(), "\u{355}");
+        assert_eq!(zalgo_decode("\u{355}").unwrap(), "u");
+        assert_eq!(zalgo_encode("v").unwrap(), "\u{356}");
+        assert_eq!(zalgo_decode("\u{356}").unwrap(), "v");
+        assert_eq!(zalgo_encode("w").unwrap(), "\u{357}");
+        assert_eq!(zalgo_decode("\u{357}").unwrap(), "w");
+        assert_eq!(zalgo_encode("x").unwrap(), "\u{358}");
+        assert_eq!(zalgo_decode("\u{358}").unwrap(), "x");
+        assert_eq!(zalgo_encode("y").unwrap(), "\u{359}");
+        assert_eq!(zalgo_decode("\u{359}").unwrap(), "y");
+        assert_eq!(zalgo_encode("z").unwrap(), "\u{35a}");
+        assert_eq!(zalgo_decode("\u{35a}").unwrap(), "z");
+        assert_eq!(zalgo_encode("1").unwrap(), "\u{311}");
+        assert_eq!(zalgo_decode("\u{311}").unwrap(), "1");
+        assert_eq!(zalgo_encode("2").unwrap(), "\u{312}");
+        assert_eq!(zalgo_decode("\u{312}").unwrap(), "2");
+        assert_eq!(zalgo_encode("3").unwrap(), "\u{313}");
+        assert_eq!(zalgo_decode("\u{313}").unwrap(), "3");
+        assert_eq!(zalgo_encode("4").unwrap(), "\u{314}");
+        assert_eq!(zalgo_decode("\u{314}").unwrap(), "4");
+        assert_eq!(zalgo_encode("5").unwrap(), "\u{315}");
+        assert_eq!(zalgo_decode("\u{315}").unwrap(), "5");
+        assert_eq!(zalgo_encode("6").unwrap(), "\u{316}");
+        assert_eq!(zalgo_decode("\u{316}").unwrap(), "6");
+        assert_eq!(zalgo_encode("7").unwrap(), "\u{317}");
+        assert_eq!(zalgo_decode("\u{317}").unwrap(), "7");
+        assert_eq!(zalgo_encode("8").unwrap(), "\u{318}");
+        assert_eq!(zalgo_decode("\u{318}").unwrap(), "8");
+        assert_eq!(zalgo_encode("9").unwrap(), "\u{319}");
+        assert_eq!(zalgo_decode("\u{319}").unwrap(), "9");
+        assert_eq!(zalgo_encode("0").unwrap(), "\u{310}");
+        assert_eq!(zalgo_decode("\u{310}").unwrap(), "0");
+        assert_eq!(zalgo_encode(" ").unwrap(), "\u{300}");
+        assert_eq!(zalgo_decode("\u{300}").unwrap(), " ");
+        assert_eq!(zalgo_encode("!").unwrap(), "\u{301}");
+        assert_eq!(zalgo_decode("\u{301}").unwrap(), "!");
+        assert_eq!(zalgo_encode("\"").unwrap(), "\u{302}");
+        assert_eq!(zalgo_decode("\u{302}").unwrap(), "\"");
+        assert_eq!(zalgo_encode("#").unwrap(), "\u{303}");
+        assert_eq!(zalgo_decode("\u{303}").unwrap(), "#");
+        assert_eq!(zalgo_encode("$").unwrap(), "\u{304}");
+        assert_eq!(zalgo_decode("\u{304}").unwrap(), "$");
+        assert_eq!(zalgo_encode("%").unwrap(), "\u{305}");
+        assert_eq!(zalgo_decode("\u{305}").unwrap(), "%");
+        assert_eq!(zalgo_encode("&").unwrap(), "\u{306}");
+        assert_eq!(zalgo_decode("\u{306}").unwrap(), "&");
+        assert_eq!(zalgo_encode("'").unwrap(), "\u{307}");
+        assert_eq!(zalgo_decode("\u{307}").unwrap(), "'");
+        assert_eq!(zalgo_encode("(").unwrap(), "\u{308}");
+        assert_eq!(zalgo_decode("\u{308}").unwrap(), "(");
+        assert_eq!(zalgo_encode(")").unwrap(), "\u{309}");
+        assert_eq!(zalgo_decode("\u{309}").unwrap(), ")");
+        assert_eq!(zalgo_encode("*").unwrap(), "\u{30a}");
+        assert_eq!(zalgo_decode("\u{30a}").unwrap(), "*");
+        assert_eq!(zalgo_encode("+").unwrap(), "\u{30b}");
+        assert_eq!(zalgo_decode("\u{30b}").unwrap(), "+");
+        assert_eq!(zalgo_encode(",").unwrap(), "\u{30c}");
+        assert_eq!(zalgo_decode("\u{30c}").unwrap(), ",");
+        assert_eq!(zalgo_encode("-").unwrap(), "\u{30d}");
+        assert_eq!(zalgo_decode("\u{30d}").unwrap(), "-");
+        assert_eq!(zalgo_encode("\\").unwrap(), "\u{33c}");
+        assert_eq!(zalgo_decode("\u{33c}").unwrap(), "\\");
+        assert_eq!(zalgo_encode(".").unwrap(), "\u{30e}");
+        assert_eq!(zalgo_decode("\u{30e}").unwrap(), ".");
+        assert_eq!(zalgo_encode("/").unwrap(), "\u{30f}");
+        assert_eq!(zalgo_decode("\u{30f}").unwrap(), "/");
+        assert_eq!(zalgo_encode(":").unwrap(), "\u{31a}");
+        assert_eq!(zalgo_decode("\u{31a}").unwrap(), ":");
+        assert_eq!(zalgo_encode(";").unwrap(), "\u{31b}");
+        assert_eq!(zalgo_decode("\u{31b}").unwrap(), ";");
+        assert_eq!(zalgo_encode("<").unwrap(), "\u{31c}");
+        assert_eq!(zalgo_decode("\u{31c}").unwrap(), "<");
+        assert_eq!(zalgo_encode("=").unwrap(), "\u{31d}");
+        assert_eq!(zalgo_decode("\u{31d}").unwrap(), "=");
+        assert_eq!(zalgo_encode(">").unwrap(), "\u{31e}");
+        assert_eq!(zalgo_decode("\u{31e}").unwrap(), ">");
+        assert_eq!(zalgo_encode("?").unwrap(), "\u{31f}");
+        assert_eq!(zalgo_decode("\u{31f}").unwrap(), "?");
+        assert_eq!(zalgo_encode("@").unwrap(), "\u{320}");
+        assert_eq!(zalgo_decode("\u{320}").unwrap(), "@");
+        assert_eq!(zalgo_encode("\n").unwrap(), "\u{36f}");
+        assert_eq!(zalgo_decode("\u{36f}").unwrap(), "\n");
     }
 }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -319,7 +319,7 @@ pub fn zalgo_decode(encoded: &str) -> Result<String, DecodeError> {
         }
     }
 
-    String::from_utf8(res).map_err(|e| DecodeError::new(e))
+    String::from_utf8(res).map_err(DecodeError::new)
 }
 
 #[inline]

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -175,7 +175,6 @@
 //!
 //! There is an executable available for experimenting with the codec on text and files.
 //! It can be installed with `cargo install zalgo-codec --features binary`.
-//! You can optionally enable the `gui` feature during installation to include a rudimentary GUI mode for the program.
 
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -307,7 +307,7 @@ pub fn zalgo_encode(string: &str) -> Result<String, EncodeError> {
 /// ```
 pub fn zalgo_decode(encoded: &str) -> Result<String, DecodeError> {
     if encoded.is_empty() {
-        return Err(DecodeError::new(None));
+        return Ok(String::new());
     }
     let mut res = vec![0; encoded.len() / 2];
     let bytes = encoded.as_bytes();
@@ -319,7 +319,7 @@ pub fn zalgo_decode(encoded: &str) -> Result<String, DecodeError> {
         }
     }
 
-    String::from_utf8(res).map_err(|e| DecodeError::new(Some(e)))
+    String::from_utf8(res).map_err(|e| DecodeError::new(e))
 }
 
 #[inline]
@@ -390,7 +390,7 @@ mod test {
 
     #[test]
     fn test_empty_decode() {
-        assert!(zalgo_decode("").is_err());
+        assert_eq!(zalgo_decode("").ok(), Some(String::new()));
     }
 
     #[test]

--- a/common/src/zalgo_string/iterators.rs
+++ b/common/src/zalgo_string/iterators.rs
@@ -12,7 +12,7 @@ pub struct DecodedBytes<'a>(core::str::Bytes<'a>);
 impl<'a> DecodedBytes<'a> {
     #[inline]
     pub(crate) fn new(zs: &'a ZalgoString) -> Self {
-        Self(zs.as_combining_chars().bytes())
+        Self(zs.as_str().bytes())
     }
 }
 

--- a/common/src/zalgo_string/mod.rs
+++ b/common/src/zalgo_string/mod.rs
@@ -87,11 +87,9 @@ impl ZalgoString {
     ///
     /// ```
     /// # use zalgo_codec_common::{EncodeError, ZalgoString};
-    /// use core::num::NonZeroUsize;
     ///
     /// // Reserve capacity for two encoded characters
-    /// let capacity = NonZeroUsize::new(2*2).unwrap();
-    /// let mut zs = ZalgoString::with_capacity(capacity);
+    /// let mut zs = ZalgoString::with_capacity(2*2);
     ///
     /// // This ZalgoString would decode into an empty string
     /// assert_eq!(zs.decoded_len(), 0);
@@ -108,8 +106,8 @@ impl ZalgoString {
     /// ```
     #[inline]
     #[must_use = "this associated method return a new `ZalgoString` and does not modify the input"]
-    pub fn with_capacity(capacity: core::num::NonZeroUsize) -> Self {
-        Self(String::with_capacity(capacity.get()))
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self(String::with_capacity(capacity))
     }
 
     // region: character access methods

--- a/common/src/zalgo_string/mod.rs
+++ b/common/src/zalgo_string/mod.rs
@@ -631,7 +631,7 @@ impl ZalgoString {
         }
     }
 
-    /// Truncates this `ZalgoString`, removing all contents.
+    /// Clears this `ZalgoString`, removing all contents.
     ///
     /// This means the ZalgoString will have a length of zero, but it does not affect its capacity.
     ///

--- a/common/src/zalgo_string/mod.rs
+++ b/common/src/zalgo_string/mod.rs
@@ -631,9 +631,9 @@ impl ZalgoString {
         }
     }
 
-    /// Truncates this `ZalgoString`, removing all contents except the initial "E".
+    /// Truncates this `ZalgoString`, removing all contents.
     ///
-    /// This means the ZalgoString will have a length of one, but it does not affect its capacity.
+    /// This means the ZalgoString will have a length of zero, but it does not affect its capacity.
     ///
     /// # Example
     ///

--- a/common/src/zalgo_string/mod.rs
+++ b/common/src/zalgo_string/mod.rs
@@ -65,44 +65,23 @@ impl TryFrom<MaybeZalgoString> for ZalgoString {
 
 /// Allocates a `String` that contains only the character "E" and no encoded content.
 impl Default for ZalgoString {
+    #[inline]
     fn default() -> Self {
-        Self(String::from('E'))
+        Self::new()
     }
 }
 
 impl ZalgoString {
-    /// Encodes the given string slice with [`zalgo_encode`] and stores the result in a new allocation.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the input string contains bytes that don't correspond to printable
-    /// ASCII characters or newlines.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use zalgo_codec_common::{EncodeError, ZalgoString};
-    /// assert_eq!(ZalgoString::new("Zalgo")?, "É̺͇͌͏");
-    /// # Ok::<(), EncodeError>(())
-    /// ```
-    /// Can only encode printable ASCII and newlines:
-    /// ```
-    /// # use zalgo_codec_common::ZalgoString;
-    /// assert!(ZalgoString::new("❤️").is_err());
-    /// assert!(ZalgoString::new("\r").is_err());
-    /// ```
-    #[must_use = "this associated method returns a new `ZalgoString` and does not modify the input"]
-    pub fn new(s: &str) -> Result<Self, EncodeError> {
-        zalgo_encode(s).map(Self)
+    /// Creates a new empty [`ZalgoString`].
+    #[inline]
+    pub const fn new() -> Self {
+        Self(String::new())
     }
 
     /// Creates a new `ZalgoString` with at least the specified capacity.
     ///
-    /// A ZalgoString always has an allocated buffer with an "E" in it,
-    /// so the capacity can not be zero.
-    ///
     /// If you want the ZalgoString to have capacity for x encoded characters
-    /// you must reserve a capacity of 2x + 1.
+    /// you must reserve a capacity of 2x.
     ///
     /// # Example
     ///
@@ -111,14 +90,14 @@ impl ZalgoString {
     /// use core::num::NonZeroUsize;
     ///
     /// // Reserve capacity for two encoded characters
-    /// let capacity = NonZeroUsize::new(2*2 + 1).unwrap();
+    /// let capacity = NonZeroUsize::new(2*2).unwrap();
     /// let mut zs = ZalgoString::with_capacity(capacity);
     ///
     /// // This ZalgoString would decode into an empty string
     /// assert_eq!(zs.decoded_len(), 0);
     ///
     /// // This allocates,
-    /// let zs2 = ZalgoString::new("Hi")?;
+    /// let zs2 = ZalgoString::try_from("Hi")?;
     ///
     /// // but this does not reallocate `zs`
     /// let cap = zs.capacity();
@@ -130,9 +109,7 @@ impl ZalgoString {
     #[inline]
     #[must_use = "this associated method return a new `ZalgoString` and does not modify the input"]
     pub fn with_capacity(capacity: core::num::NonZeroUsize) -> Self {
-        let mut s = String::with_capacity(capacity.get());
-        s.push('E');
-        Self(s)
+        Self(String::with_capacity(capacity.get()))
     }
 
     // region: character access methods
@@ -144,16 +121,16 @@ impl ZalgoString {
     /// Basic usage
     /// ```
     /// # use zalgo_codec_common::{EncodeError, ZalgoString};
-    /// let zs = ZalgoString::new("Oh boy!")?;
-    /// assert_eq!(zs.as_str(), "È̯͈͂͏͙́");
+    /// let zs = ZalgoString::try_from("Oh boy!")?;
+    /// assert_eq!(zs.as_str(), "̯͈̀͂͏͙́");
     /// # Ok::<(), EncodeError>(())
     /// ```
     /// Note that `ZalgoString` implements [`PartialEq`] with common string types,
     /// so the comparison in the above example could also be done directly
     /// ```
     /// # use zalgo_codec_common::{EncodeError, ZalgoString};
-    /// # let zs = ZalgoString::new("Oh boy!")?;
-    /// assert_eq!(zs, "È̯͈͂͏͙́");
+    /// # let zs = ZalgoString::try_from("Oh boy!")?;
+    /// assert_eq!(zs, "̯͈̀͂͏͙́");
     /// # Ok::<(), EncodeError>(())
     /// ```
     #[inline]
@@ -173,11 +150,11 @@ impl ZalgoString {
     ///
     /// ```
     /// # use zalgo_codec_common::{EncodeError, ZalgoString};
-    /// let zs = ZalgoString::new("Zalgo")?;
-    /// assert_eq!(zs.get(0..3), Some("E\u{33a}"));
+    /// let zs = ZalgoString::try_from("Zalgo")?;
+    /// assert_eq!(zs.get(0..2), Some("\u{33a}"));
     ///
     /// // indices not on UTF-8 sequence boundaries
-    /// assert!(zs.get(0..4).is_none());
+    /// assert!(zs.get(0..3).is_none());
     ///
     /// // out of bounds
     /// assert!(zs.get(..42).is_none());
@@ -206,9 +183,9 @@ impl ZalgoString {
     ///
     /// ```
     /// # use zalgo_codec_common::{EncodeError, ZalgoString};
-    /// let zs = ZalgoString::new("Zalgo")?;
+    /// let zs = ZalgoString::try_from("Zalgo")?;
     /// unsafe {
-    ///     assert_eq!(zs.get_unchecked(..3), "E\u{33a}");
+    ///     assert_eq!(zs.get_unchecked(..2), "\u{33a}");
     /// }
     /// # Ok::<(), EncodeError>(())
     /// ```
@@ -222,16 +199,13 @@ impl ZalgoString {
 
     /// Returns an iterator over the encoded characters of the `ZalgoString`.
     ///
-    /// The first character is an "E", the others are unicode combining characters.
-    ///
     /// # Example
     ///
     /// Iterate through the encoded [`char`]s:
     /// ```
     /// # use zalgo_codec_common::{EncodeError, ZalgoString};
-    /// let zs = ZalgoString::new("42")?;
+    /// let zs = ZalgoString::try_from("42")?;
     /// let mut chars = zs.chars();
-    /// assert_eq!(chars.next(), Some('E'));
     /// assert_eq!(chars.next(), Some('\u{314}'));
     /// # Ok::<(), EncodeError>(())
     /// ```
@@ -248,16 +222,15 @@ impl ZalgoString {
     /// and may not match with your intuition of what a character is.
     /// ```
     /// # use zalgo_codec_common::{EncodeError, ZalgoString};
-    /// let zs = ZalgoString::new("Zalgo")?;
+    /// let zs = ZalgoString::try_from("Zalgo")?;
     /// let mut ci = zs.char_indices();
-    /// assert_eq!(ci.next(), Some((0, 'E')));
-    /// assert_eq!(ci.next(), Some((1,'\u{33a}')));
+    /// assert_eq!(ci.next(), Some((0,'\u{33a}')));
     /// // Note the 3 here, the combining characters take up two bytes.
-    /// assert_eq!(ci.next(), Some((3, '\u{341}')));
+    /// assert_eq!(ci.next(), Some((2, '\u{341}')));
     /// // The final character begins at position 9
-    /// assert_eq!(ci.next_back(), Some((9, '\u{34f}')));
-    /// // even though the length in bytes is 11
-    /// assert_eq!(zs.len(), 11);
+    /// assert_eq!(ci.next_back(), Some((8, '\u{34f}')));
+    /// // even though the length in bytes is 10
+    /// assert_eq!(zs.len(), 10);
     /// # Ok::<(), EncodeError>(())
     /// ```
     #[inline]
@@ -273,7 +246,7 @@ impl ZalgoString {
     ///
     /// ```
     /// # use zalgo_codec_common::{EncodeError, ZalgoString};
-    /// let zs = ZalgoString::new("Zlgoa")?;
+    /// let zs = ZalgoString::try_from("Zlgoa")?;
     /// let mut decoded_chars = zs.decoded_chars();
     /// assert_eq!(decoded_chars.next(), Some('Z'));
     /// assert_eq!(decoded_chars.next_back(), Some('a'));
@@ -298,8 +271,8 @@ impl ZalgoString {
     /// Basic usage
     /// ```
     /// # use zalgo_codec_common::{EncodeError, ZalgoString};
-    /// let zs = ZalgoString::new("Zalgo\n He comes!")?;
-    /// assert_eq!(zs.into_string(), "É̺͇͌͏̨ͯ̀̀̓ͅ͏͍͓́ͅ");
+    /// let zs = ZalgoString::try_from("Zalgo\n He comes!")?;
+    /// assert_eq!(zs.into_string(), "̺͇́͌͏̨ͯ̀̀̓ͅ͏͍͓́ͅ");
     /// # Ok::<(), EncodeError>(())
     /// ```
     #[inline]
@@ -318,7 +291,7 @@ impl ZalgoString {
     /// ```
     /// # use zalgo_codec_common::{EncodeError, ZalgoString};
     /// let s = "Zalgo";
-    /// let zs = ZalgoString::new(s)?;
+    /// let zs = ZalgoString::try_from(s)?;
     /// assert_eq!(s, zs.into_decoded_string());
     /// # Ok::<(), EncodeError>(())
     /// ```
@@ -335,17 +308,13 @@ impl ZalgoString {
 
     /// Returns the encoded contents of `self` as a byte slice.
     ///
-    /// The first byte is always 69, after that the bytes no longer correspond to ASCII characters.
-    ///
     /// # Example
     ///
     /// Basic usage
     /// ```
     /// # use zalgo_codec_common::{EncodeError, ZalgoString};
-    /// let zs = ZalgoString::new("Zalgo")?;
-    /// let bytes = zs.as_bytes();
-    /// assert_eq!(bytes[0], 69);
-    /// assert_eq!(&bytes[1..5], &[204, 186, 205, 129]);
+    /// let zs = ZalgoString::try_from("Zalgo")?;
+    /// assert_eq!(&zs.as_bytes()[0..4], &[204, 186, 205, 129]);
     /// # Ok::<(), EncodeError>(())
     /// ```
     #[inline]
@@ -356,17 +325,13 @@ impl ZalgoString {
 
     /// Returns an iterator over the encoded bytes of the `ZalgoString`.
     ///
-    /// Since a `ZalgoString` always begins with an "E", the first byte is always 69.
-    /// After that the bytes no longer correspond to ASCII values.
-    ///
     /// # Example
     ///
     /// Basic usage
     /// ```
     /// # use zalgo_codec_common::{EncodeError, ZalgoString};
-    /// let zs = ZalgoString::new("Bytes")?;
+    /// let zs = ZalgoString::try_from("Bytes")?;
     /// let mut bytes = zs.bytes();
-    /// assert_eq!(bytes.next(), Some(69));
     /// assert_eq!(bytes.nth(5), Some(148));
     /// # Ok::<(), EncodeError>(())
     /// ```
@@ -383,7 +348,7 @@ impl ZalgoString {
     ///
     /// ```
     /// # use zalgo_codec_common::{EncodeError, ZalgoString};
-    /// let zs = ZalgoString::new("Zalgo")?;
+    /// let zs = ZalgoString::try_from("Zalgo")?;
     /// let mut decoded_bytes = zs.decoded_bytes();
     /// assert_eq!(decoded_bytes.next(), Some(90));
     /// assert_eq!(decoded_bytes.next_back(), Some(111));
@@ -404,8 +369,8 @@ impl ZalgoString {
     /// Basic usage
     /// ```
     /// # use zalgo_codec_common::{EncodeError, ZalgoString};
-    /// let zs = ZalgoString::new("Zalgo")?;
-    /// assert_eq!(zs.into_bytes(), vec![69, 204, 186, 205, 129, 205, 140, 205, 135, 205, 143]);
+    /// let zs = ZalgoString::try_from("Zalgo")?;
+    /// assert_eq!(zs.into_bytes(), vec![204, 186, 205, 129, 205, 140, 205, 135, 205, 143]);
     /// # Ok::<(), EncodeError>(())
     /// ```
     #[inline]
@@ -423,7 +388,7 @@ impl ZalgoString {
     /// Basic usage
     /// ```
     /// # use zalgo_codec_common::{EncodeError, ZalgoString};
-    /// let zs = ZalgoString::new("Zalgo")?;
+    /// let zs = ZalgoString::try_from("Zalgo")?;
     /// assert_eq!(b"Zalgo".to_vec(), zs.into_decoded_bytes());
     /// # Ok::<(), EncodeError>(())
     /// ```
@@ -431,7 +396,7 @@ impl ZalgoString {
     pub fn into_decoded_bytes(self) -> Vec<u8> {
         let mut w = 0;
         let mut bytes = self.into_bytes();
-        for r in (1..bytes.len()).step_by(2) {
+        for r in (0..bytes.len()).step_by(2) {
             bytes[w] = decode_byte_pair(bytes[r], bytes[r + 1]);
             w += 1;
         }
@@ -445,21 +410,18 @@ impl ZalgoString {
 
     /// Returns the length of `self` in bytes.
     ///
-    /// This length is twice the length of the original `String` plus one.
+    /// This length is twice the length of the original `String`.
     ///
     /// # Example
     ///
     /// Basic usage
     /// ```
     /// # use zalgo_codec_common::{EncodeError, ZalgoString};
-    /// let zs = ZalgoString::new("Z")?;
-    /// assert_eq!(zs.len(), 3);
+    /// let zs = ZalgoString::try_from("Z")?;
+    /// assert_eq!(zs.len(), 2);
     /// # Ok::<(), EncodeError>(())
     /// ```
-    // Since the length is never empty it makes no sense to have an is_empty function.
-    // The decoded length can be empty though, so `decoded_is_empty` is provided instead.
     #[inline]
-    #[allow(clippy::len_without_is_empty)]
     #[must_use = "the method returns a new value and does not modify `self`"]
     pub fn len(&self) -> usize {
         self.0.len()
@@ -468,7 +430,7 @@ impl ZalgoString {
     /// Returns the capacity of the underlying encoded string in bytes.
     ///
     /// The `ZalgoString` is preallocated to the needed capacity of twice the length
-    /// of the original unencoded `String` plus one.
+    /// of the original unencoded `String`.
     /// However, this size is not guaranteed since the allocator can choose to allocate more space.
     #[inline]
     #[must_use = "the method returns a new value and does not modify `self`"]
@@ -486,14 +448,14 @@ impl ZalgoString {
     /// ```
     /// # use zalgo_codec_common::{EncodeError, ZalgoString};
     /// let s = "Zalgo, He comes!";
-    /// let zs = ZalgoString::new(s)?;
+    /// let zs = ZalgoString::try_from(s)?;
     /// assert_eq!(s.len(), zs.decoded_len());
     /// # Ok::<(), EncodeError>(())
     /// ```
     #[inline]
     #[must_use = "the method returns a new value and does not modify `self`"]
     pub fn decoded_len(&self) -> usize {
-        (self.len() - 1) / 2
+        self.len() / 2
     }
 
     /// Returns whether the string would be empty if decoded.
@@ -503,64 +465,19 @@ impl ZalgoString {
     /// Basic usage
     /// ```
     /// # use zalgo_codec_common::{EncodeError, ZalgoString};
-    /// let zs = ZalgoString::new("")?;
-    /// assert!(zs.decoded_is_empty());
-    /// let zs = ZalgoString::new("Blargh")?;
-    /// assert!(!zs.decoded_is_empty());
+    /// let zs = ZalgoString::try_from("")?;
+    /// assert!(zs.is_empty());
+    /// let zs = ZalgoString::try_from("Blargh")?;
+    /// assert!(!zs.is_empty());
     /// # Ok::<(), EncodeError>(())
     /// ```
     #[inline]
     #[must_use = "the method returns a new value and does not modify `self`"]
-    pub fn decoded_is_empty(&self) -> bool {
+    pub fn is_empty(&self) -> bool {
         self.decoded_len() == 0
     }
 
     // endregion: metadata methods
-
-    /// Returns a string slice of just the combining characters of the `ZalgoString` without the inital 'E'.
-    ///
-    /// Note that [`zalgo_decode`](crate::zalgo_decode) assumes that the initial 'E' is present,
-    /// and can not decode the result of this method.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use zalgo_codec_common::{EncodeError, ZalgoString};
-    /// let zs = ZalgoString::new("Hi")?;
-    /// assert_eq!(zs.as_combining_chars(), "\u{328}\u{349}");
-    /// # Ok::<(), EncodeError>(())
-    /// ```
-    #[inline]
-    #[must_use = "the method returns a new value and does not modify `self`"]
-    pub fn as_combining_chars(&self) -> &str {
-        self.0.split_at(1).1
-    }
-
-    /// Converts `self` into a String that contains only the combining characters of the grapheme cluster.
-    ///
-    /// This is an `O(n)` operation since after it has removed the initial "E" it needs to copy every byte
-    /// of the string down one index.
-    ///
-    /// It is the same as calling [`ZalgoString::into_string()`] followed by [`String::remove(0)`](String::remove).
-    ///
-    /// Just like [`as_combining_chars`](ZalgoString::as_combining_chars) the result of this method can not
-    /// be decoded by [`zalgo_decode`](crate::zalgo_decode).
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use zalgo_codec_common::{EncodeError, ZalgoString};
-    /// let zs = ZalgoString::new("Hi")?;
-    /// let s = zs.into_combining_chars();
-    /// assert_eq!(s, "\u{328}\u{349}");
-    /// # Ok::<(), EncodeError>(())
-    /// ```
-    #[inline]
-    #[must_use = "`self` will be dropped if the result is not used"]
-    pub fn into_combining_chars(mut self) -> String {
-        self.0.remove(0);
-        self.0
-    }
 
     /// Appends the combining characters of a different `ZalgoString` to the end of `self`.
     ///
@@ -570,8 +487,8 @@ impl ZalgoString {
     /// # use zalgo_codec_common::{EncodeError, ZalgoString};
     /// let (s1, s2) = ("Zalgo", ", He comes!");
     ///
-    /// let mut zs1 = ZalgoString::new(s1)?;
-    /// let zs2 = ZalgoString::new(s2)?;
+    /// let mut zs1 = ZalgoString::try_from(s1)?;
+    /// let zs2 = ZalgoString::try_from(s2)?;
     ///
     /// zs1.push_zalgo_str(&zs2);
     ///
@@ -580,7 +497,7 @@ impl ZalgoString {
     /// ```
     #[inline]
     pub fn push_zalgo_str(&mut self, zalgo_string: &Self) {
-        self.0.push_str(zalgo_string.as_combining_chars());
+        self.0.push_str(zalgo_string.as_str());
     }
 
     /// Encodes the given string and pushes it onto `self`.
@@ -603,7 +520,7 @@ impl ZalgoString {
     /// # use zalgo_codec_common::{EncodeError, ZalgoString};
     /// let (s1, s2) = ("Zalgo", ", He comes!");
     ///
-    /// let mut zs = ZalgoString::new(s1)?;
+    /// let mut zs = ZalgoString::try_from(s1)?;
     ///
     /// zs.encode_and_push_str(s2)?;
     ///
@@ -611,7 +528,7 @@ impl ZalgoString {
     /// # Ok::<(), EncodeError>(())
     /// ```
     pub fn encode_and_push_str(&mut self, string: &str) -> Result<(), EncodeError> {
-        self.push_zalgo_str(&ZalgoString::new(string)?);
+        self.push_zalgo_str(&ZalgoString::try_from(string)?);
         Ok(())
     }
 
@@ -626,17 +543,17 @@ impl ZalgoString {
     ///
     /// Does nothing if the capacity is already sufficient.
     ///
-    /// Keep in mind that an encoded ASCII character takes up two bytes, and that a `ZalgoString`
-    /// always begins with an unencoded "E" which means that the total length in bytes is always an odd number.
+    /// Keep in mind that an encoded ASCII character takes up two bytes,
+    /// which means that the total length in bytes is always an even number.
     ///
     /// # Example
     ///
     /// ```
     /// # use zalgo_codec_common::{EncodeError, ZalgoString};
-    /// let mut zs = ZalgoString::new("Zalgo")?;
+    /// let mut zs = ZalgoString::try_from("Zalgo")?;
     /// let c = zs.capacity();
-    /// zs.reserve(5);
-    /// assert!(zs.capacity() >= c + 5);
+    /// zs.reserve(4);
+    /// assert!(zs.capacity() >= c + 4);
     /// # Ok::<(), EncodeError>(())
     /// ```
     #[inline]
@@ -654,14 +571,14 @@ impl ZalgoString {
     ///
     /// Does nothing if the capacity is already sufficient.
     ///
-    /// Keep in mind that an encoded ASCII character takes up two bytes, and that a `ZalgoString`
-    /// always begins with an unencoded "E" which means that the total length in bytes is always an odd number.
+    /// Keep in mind that an encoded ASCII character takes up two bytes,
+    /// which means that the total length in bytes is always an odd number.
     ///
     /// # Example
     ///
     /// ```
     /// # use zalgo_codec_common::{EncodeError, ZalgoString};
-    /// let mut zs = ZalgoString::new("Zalgo")?;
+    /// let mut zs = ZalgoString::try_from("Zalgo")?;
     /// let c = zs.capacity();
     /// zs.reserve_exact(5);
     /// assert!(zs.capacity() >= c + 5);
@@ -678,8 +595,7 @@ impl ZalgoString {
 
     /// Shortens the `ZalgoString` to the specified length.
     ///
-    /// A `ZalgoString` always takes up an odd number of bytes as the first "E" takes up one,
-    /// and all subsequent characters take up two.
+    /// A `ZalgoString` always takes up an even number of bytes as all encoded characters take up two bytes.
     ///
     /// If `new_len` is larger than its current length, this has no effect.
     ///
@@ -687,29 +603,29 @@ impl ZalgoString {
     ///
     /// # Panics
     ///
-    /// Panics if `new_len` is even.
+    /// Panics if `new_len` is odd.
     ///
     /// # Examples
     ///
     /// ```
     /// # use zalgo_codec_common::{EncodeError, ZalgoString};
-    /// let mut zs = ZalgoString::new("Zalgo")?;
-    /// zs.truncate(5);
-    /// assert_eq!(zs, "E\u{33a}\u{341}");
+    /// let mut zs = ZalgoString::try_from("Zalgo")?;
+    /// zs.truncate(4);
+    /// assert_eq!(zs, "\u{33a}\u{341}");
     /// assert_eq!(zs.into_decoded_string(), "Za");
     /// # Ok::<(), EncodeError>(())
     /// ```
-    /// Panics if `new_len` is even:
+    /// Panics if `new_len` is odd:
     /// ```should_panic
     /// # use zalgo_codec_common::{EncodeError, ZalgoString};
-    /// let mut zs = ZalgoString::new("Zalgo")?;
-    /// zs.truncate(0);
+    /// let mut zs = ZalgoString::try_from("Zalgo")?;
+    /// zs.truncate(1);
     /// # Ok::<(), EncodeError>(())
     /// ```
     #[inline]
     pub fn truncate(&mut self, new_len: usize) {
         if new_len <= self.len() {
-            assert_eq!(new_len % 2, 1, "the new length must be odd");
+            assert_eq!(new_len % 2, 0, "the new length must be even");
             self.0.truncate(new_len)
         }
     }
@@ -722,17 +638,47 @@ impl ZalgoString {
     ///
     /// ```
     /// # use zalgo_codec_common::{EncodeError, ZalgoString};
-    /// let mut zs = ZalgoString::new("Zalgo")?;
+    /// let mut zs = ZalgoString::try_from("Zalgo")?;
     /// zs.clear();
-    /// assert_eq!(zs, "E");
-    /// assert!(zs.decoded_is_empty());
+    /// assert!(zs.is_empty());
     /// # Ok::<(), EncodeError>(())
     /// ```
     pub fn clear(&mut self) {
-        self.truncate(1)
+        self.0.clear()
     }
 
     // endregion: length manipulation methods
+}
+
+impl TryFrom<&str> for ZalgoString {
+    type Error = EncodeError;
+
+    /// Encodes the given string slice and stores the result in a new allocation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the input string contains bytes that don’t correspond to printable ASCII characters or newlines.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use zalgo_codec_common::{EncodeError, ZalgoString};
+    ///
+    /// assert_eq!(ZalgoString::try_from("Zalgo")?, "̺͇́͌͏");
+    ///
+    /// # Ok::<(), EncodeError>(())
+    /// ```
+    ///
+    /// Can only encode printable ASCII and newlines:
+    ///
+    /// ```
+    /// # use zalgo_codec_common::ZalgoString;
+    /// assert!(ZalgoString::try_from("❤️").is_err());
+    /// assert!(ZalgoString::try_from("\r").is_err());
+    /// ```
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        zalgo_encode(s).map(Self)
+    }
 }
 
 // region: Addition impls
@@ -814,27 +760,27 @@ mod test {
     #[test]
     fn check_into_decoded_string() {
         let s = "Zalgo\n He comes!";
-        let zs: ZalgoString = ZalgoString::new(s).unwrap();
+        let zs: ZalgoString = ZalgoString::try_from(s).unwrap();
         assert_eq!(zs.into_decoded_string(), s);
 
-        let zs = ZalgoString::new("").unwrap();
-        assert_eq!(zs.into_decoded_string(), "");
+        let zs = ZalgoString::new();
+        assert_eq!(zs.into_decoded_string(), String::new());
     }
 
     #[test]
     fn check_string_from_zalgo_string() {
-        let zs = ZalgoString::new("Zalgo\n He comes!").unwrap();
-        assert_eq!(zs.to_string(), "É̺͇͌͏̨ͯ̀̀̓ͅ͏͍͓́ͅ");
-        assert_eq!(zs.into_string(), "É̺͇͌͏̨ͯ̀̀̓ͅ͏͍͓́ͅ");
+        let zs = ZalgoString::try_from("Zalgo\n He comes!").unwrap();
+        assert_eq!(zs.to_string(), "̺͇́͌͏̨ͯ̀̀̓ͅ͏͍͓́ͅ");
+        assert_eq!(zs.into_string(), "̺͇́͌͏̨ͯ̀̀̓ͅ͏͍͓́ͅ");
 
-        let zs = ZalgoString::new("").unwrap();
-        assert_eq!(zs.into_string(), "E");
+        let zs = ZalgoString::new();
+        assert_eq!(zs.into_string(), String::new());
     }
 
     #[test]
     fn check_partial_eq() {
-        let enc = "É̺͇͌͏̨ͯ̀̀̓ͅ͏͍͓́ͅ";
-        let zs = ZalgoString::new("Zalgo\n He comes!").unwrap();
+        let enc = "̺͇́͌͏̨ͯ̀̀̓ͅ͏͍͓́ͅ";
+        let zs = ZalgoString::try_from("Zalgo\n He comes!").unwrap();
         assert_eq!(zs, enc);
         assert_eq!(zs, String::from(enc));
         assert_eq!(zs, Cow::from(enc));
@@ -846,8 +792,8 @@ mod test {
     fn check_push_str() {
         let s1 = "Zalgo";
         let s2 = ", He comes";
-        let mut zs = ZalgoString::new(s1).unwrap();
-        let zs2 = ZalgoString::new(s2).unwrap();
+        let mut zs = ZalgoString::try_from(s1).unwrap();
+        let zs2 = ZalgoString::try_from(s2).unwrap();
         zs.push_zalgo_str(&zs2);
         assert_eq!(zs.clone().into_decoded_string(), format!("{s1}{s2}"));
         zs += &zs2;
@@ -858,25 +804,25 @@ mod test {
     }
 
     #[test]
-    fn check_as_combining_chars() {
+    fn check_as_str() {
         assert_eq!(
-            ZalgoString::new("Hi").unwrap().as_combining_chars(),
+            ZalgoString::try_from("Hi").unwrap().as_str(),
             "\u{328}\u{349}"
         );
-        assert_eq!(ZalgoString::new("").unwrap().as_combining_chars(), "");
+        assert_eq!(ZalgoString::try_from("").unwrap().as_str(), "");
     }
 
     #[test]
     fn check_decoded_chars() {
-        let zs = ZalgoString::new("Zalgo").unwrap();
+        let zs = ZalgoString::try_from("Zalgo").unwrap();
         assert_eq!("oglaZ", zs.decoded_chars().rev().collect::<String>());
     }
 
     #[test]
     fn test_reserve() {
-        let mut zs = ZalgoString::new("Zalgo").unwrap();
+        let mut zs = ZalgoString::try_from("Zalgo").unwrap();
         zs.reserve(5);
-        assert!(zs.capacity() >= 11 + 5);
+        assert!(zs.capacity() >= 10 + 5);
         let c = zs.capacity();
         zs.reserve(1);
         assert_eq!(zs.capacity(), c);
@@ -884,9 +830,9 @@ mod test {
 
     #[test]
     fn test_reserve_exact() {
-        let mut zs = ZalgoString::new("Zalgo").unwrap();
+        let mut zs = ZalgoString::try_from("Zalgo").unwrap();
         zs.reserve_exact(5);
-        assert_eq!(zs.capacity(), 11 + 5);
+        assert_eq!(zs.capacity(), 10 + 5);
         let c = zs.capacity();
         zs.reserve_exact(1);
         assert_eq!(zs.capacity(), c);
@@ -894,41 +840,41 @@ mod test {
 
     #[test]
     fn test_truncate() {
-        let mut zs = ZalgoString::new("Zalgo").unwrap();
+        let mut zs = ZalgoString::try_from("Zalgo").unwrap();
         zs.truncate(100);
-        assert_eq!(zs, "E\u{33a}\u{341}\u{34c}\u{347}\u{34f}");
-        zs.truncate(5);
-        assert_eq!(zs, "E\u{33a}\u{341}");
+        assert_eq!(zs, "\u{33a}\u{341}\u{34c}\u{347}\u{34f}");
+        zs.truncate(4);
+        assert_eq!(zs, "\u{33a}\u{341}");
         assert_eq!(zs.into_decoded_string(), "Za");
     }
 
     #[test]
     #[should_panic]
     fn test_truncate_panic() {
-        let mut zs = ZalgoString::new("Zalgo").unwrap();
-        zs.truncate(0)
+        let mut zs = ZalgoString::try_from("Zalgo").unwrap();
+        zs.truncate(1)
     }
 
     #[test]
     fn test_default() {
-        assert_eq!(ZalgoString::new("").unwrap(), ZalgoString::default());
+        assert_eq!(ZalgoString::try_from("").unwrap(), ZalgoString::default());
     }
 
     #[test]
     fn test_with_capacity() {
-        let mut zs = ZalgoString::with_capacity(11.try_into().unwrap());
-        assert_eq!(zs.capacity(), 11);
+        let mut zs = ZalgoString::with_capacity(10.try_into().unwrap());
+        assert_eq!(zs.capacity(), 10);
         zs.encode_and_push_str("Hi!").unwrap();
-        assert_eq!(zs.capacity(), 11);
+        assert_eq!(zs.capacity(), 10);
         zs.encode_and_push_str("I am a dinosaur!").unwrap();
-        assert!(zs.capacity() > 11);
+        assert!(zs.capacity() > 10);
     }
 
     #[test]
     fn test_as_str() {
         fn test_fn(_: &str) {}
         let s = "Zalgo";
-        let zs = ZalgoString::new(s).unwrap();
+        let zs = ZalgoString::try_from(s).unwrap();
         let encd = zalgo_encode(s).unwrap();
         test_fn(zs.as_str());
         assert_eq!(zs.as_str(), encd);
@@ -937,47 +883,46 @@ mod test {
     #[test]
     fn test_chars() {
         let s = "Zalgo";
-        let zs = ZalgoString::new(s).unwrap();
+        let zs = ZalgoString::try_from(s).unwrap();
         let encd = zalgo_encode(s).unwrap();
         for (a, b) in zs.chars().zip(encd.chars()) {
             assert_eq!(a, b);
         }
-        assert_eq!(zs.chars().next(), Some('E'));
-        assert_eq!(zs.chars().nth(2), Some('\u{341}'));
+        assert_eq!(zs.chars().nth(1), Some('\u{341}'));
     }
 
     #[test]
     fn test_char_indices() {
         let s = "Zalgo";
-        let zs = ZalgoString::new(s).unwrap();
+        let zs = ZalgoString::try_from(s).unwrap();
         let encd = zalgo_encode(s).unwrap();
         for (a, b) in zs.char_indices().zip(encd.char_indices()) {
             assert_eq!(a, b);
         }
-        assert_eq!(zs.char_indices().nth(2), Some((3, '\u{341}')));
+        assert_eq!(zs.char_indices().nth(1), Some((2, '\u{341}')));
     }
 
     #[test]
     fn test_as_bytes() {
-        let zs = ZalgoString::new("Zalgo").unwrap();
+        let zs = ZalgoString::try_from("Zalgo").unwrap();
         assert_eq!(
             zs.as_bytes(),
-            &[69, 204, 186, 205, 129, 205, 140, 205, 135, 205, 143]
+            &[204, 186, 205, 129, 205, 140, 205, 135, 205, 143]
         );
     }
 
     #[test]
     fn test_bytes() {
-        let zs = ZalgoString::new("Zalgo").unwrap();
-        assert_eq!(zs.bytes().next(), Some(69));
-        assert_eq!(zs.bytes().nth(2), Some(186));
+        let zs = ZalgoString::try_from("Zalgo").unwrap();
+        assert_eq!(zs.bytes().next(), Some(204));
+        assert_eq!(zs.bytes().nth(2), Some(205));
     }
 
     #[test]
-    fn test_decoded_is_empty() {
-        let zs = ZalgoString::new("Zalgo").unwrap();
-        assert!(!zs.decoded_is_empty());
-        assert!(ZalgoString::default().decoded_is_empty());
+    fn test_is_empty() {
+        let zs = ZalgoString::try_from("Zalgo").unwrap();
+        assert!(!zs.is_empty());
+        assert!(ZalgoString::default().is_empty());
     }
 
     #[test]
@@ -990,51 +935,52 @@ mod test {
 
     #[test]
     fn test_clear() {
-        let mut zs = ZalgoString::new("Zalgo").unwrap();
+        let mut zs = ZalgoString::try_from("Zalgo").unwrap();
         let c = zs.capacity();
         zs.clear();
         assert_eq!(zs.capacity(), c);
-        assert_eq!(zs.len(), 1);
+        assert_eq!(zs.len(), 0);
         assert_eq!(zs.decoded_len(), 0);
+        assert!(zs.is_empty());
         assert!(zs.into_decoded_string().is_empty());
     }
 
     #[test]
     fn test_get() {
-        let zs = ZalgoString::new("Zalgo").unwrap();
-        assert_eq!(zs.get(0..3), Some("E\u{33a}"));
-        assert!(zs.get(0..2).is_none());
+        let zs = ZalgoString::try_from("Zalgo").unwrap();
+        assert_eq!(zs.get(0..2), Some("\u{33a}"));
+        assert!(zs.get(0..1).is_none());
         assert!(zs.get(0..42).is_none());
     }
 
     #[test]
     fn test_get_unchecked() {
-        let zs = ZalgoString::new("Zalgo").unwrap();
+        let zs = ZalgoString::try_from("Zalgo").unwrap();
         unsafe {
-            assert_eq!(zs.get_unchecked(..3), "E\u{33a}");
+            assert_eq!(zs.get_unchecked(..2), "\u{33a}");
         }
     }
 
     #[test]
     fn test_indexing() {
-        let zs = ZalgoString::new("Zalgo").unwrap();
-        assert_eq!(&zs[0..3], "E\u{33a}");
-        assert_eq!(&zs[..3], "E\u{33a}");
-        assert_eq!(&zs[0..=2], "E\u{33a}");
-        assert_eq!(&zs[..=2], "E\u{33a}");
+        let zs = ZalgoString::try_from("Zalgo").unwrap();
+        assert_eq!(&zs[0..2], "\u{33a}");
+        assert_eq!(&zs[..2], "\u{33a}");
+        assert_eq!(&zs[0..=1], "\u{33a}");
+        assert_eq!(&zs[..=1], "\u{33a}");
         assert_eq!(zs[..], zs);
     }
 
     #[test]
     #[should_panic]
     fn test_index_panic() {
-        let zs = ZalgoString::new("Zalgo").unwrap();
-        let _a = &zs[0..2];
+        let zs = ZalgoString::try_from("Zalgo").unwrap();
+        let _a = &zs[0..3];
     }
 
     #[test]
     fn test_decoded_bytes() {
-        let zs = ZalgoString::new("Zalgo").unwrap();
+        let zs = ZalgoString::try_from("Zalgo").unwrap();
         assert_eq!(zs.decoded_bytes().next(), Some(b'Z'));
         assert_eq!(zs.decoded_bytes().nth(2), Some(b'l'));
         assert_eq!(zs.decoded_bytes().last(), Some(b'o'));
@@ -1047,7 +993,7 @@ mod test {
 
     #[test]
     fn test_decoded_chars() {
-        let zs = ZalgoString::new("Zalgo").unwrap();
+        let zs = ZalgoString::try_from("Zalgo").unwrap();
         assert_eq!(zs.decoded_chars().next(), Some('Z'));
         assert_eq!(zs.decoded_chars().nth(2), Some('l'));
         assert_eq!(zs.decoded_chars().last(), Some('o'));
@@ -1059,11 +1005,11 @@ mod test {
     }
 
     #[test]
-    fn test_into_combining_chars() {
-        let zs = ZalgoString::new("Hi").unwrap();
-        assert_eq!(zs.into_combining_chars(), "\u{328}\u{349}");
-        let zs = ZalgoString::new("").unwrap();
-        assert_eq!(zs.into_combining_chars(), "");
+    fn test_into_string() {
+        let zs = ZalgoString::try_from("Hi").unwrap();
+        assert_eq!(zs.into_string(), "\u{328}\u{349}");
+        let zs = ZalgoString::try_from("").unwrap();
+        assert_eq!(zs.into_string(), "");
     }
 
     #[cfg(feature = "serde")]
@@ -1071,7 +1017,7 @@ mod test {
     fn serde_deserialize_zalgo_string() {
         use serde_json::from_str;
         let s = "Zalgo";
-        let zs = ZalgoString::new(s).unwrap();
+        let zs = ZalgoString::try_from(s).unwrap();
         let json = format!(r#""{}""#, zs);
         let deserialized: ZalgoString = from_str(&json).unwrap();
         assert_eq!(deserialized, zs);

--- a/common/src/zalgo_string/mod.rs
+++ b/common/src/zalgo_string/mod.rs
@@ -640,8 +640,12 @@ impl ZalgoString {
     /// ```
     /// # use zalgo_codec_common::{EncodeError, ZalgoString};
     /// let mut zs = ZalgoString::try_from("Zalgo")?;
+    /// let cap = zs.capacity();
+    ///
     /// zs.clear();
+    ///
     /// assert!(zs.is_empty());
+    /// assert_eq!(zs.capacity(), cap);
     /// # Ok::<(), EncodeError>(())
     /// ```
     pub fn clear(&mut self) {

--- a/common/src/zalgo_string/mod.rs
+++ b/common/src/zalgo_string/mod.rs
@@ -458,15 +458,16 @@ impl ZalgoString {
         self.len() / 2
     }
 
-    /// Returns whether the string would be empty if decoded.
+    /// Returns whether the `ZalgoString` is empty.
     ///
     /// # Example
     ///
     /// Basic usage
     /// ```
     /// # use zalgo_codec_common::{EncodeError, ZalgoString};
-    /// let zs = ZalgoString::try_from("")?;
+    /// let zs = ZalgoString::new();
     /// assert!(zs.is_empty());
+    ///
     /// let zs = ZalgoString::try_from("Blargh")?;
     /// assert!(!zs.is_empty());
     /// # Ok::<(), EncodeError>(())
@@ -474,7 +475,7 @@ impl ZalgoString {
     #[inline]
     #[must_use = "the method returns a new value and does not modify `self`"]
     pub fn is_empty(&self) -> bool {
-        self.decoded_len() == 0
+        self.len() == 0
     }
 
     // endregion: metadata methods
@@ -580,8 +581,8 @@ impl ZalgoString {
     /// # use zalgo_codec_common::{EncodeError, ZalgoString};
     /// let mut zs = ZalgoString::try_from("Zalgo")?;
     /// let c = zs.capacity();
-    /// zs.reserve_exact(5);
-    /// assert!(zs.capacity() >= c + 5);
+    /// zs.reserve_exact(4);
+    /// assert!(zs.capacity() >= c + 4);
     /// # Ok::<(), EncodeError>(())
     /// ```
     #[inline]

--- a/macro/CHANGELOG.md
+++ b/macro/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This document contains all changes to the crate since 0.1.19
 
+## 0.2.0
+
+- Updated the `zalgo-codec-common` dependency.
+ This changes the encoded format to no longer have the initial "E",
+ see the changelog of `zalgo-codec-common` for more information.  
+
 ## 0.1.34
 
 - Updated the `zalgo-codec-common` dependency.

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zalgo-codec-macro"
-version = "0.1.34"
+version = "0.2.0"
 edition = "2021"
 keywords = ["unicode", "obfuscation", "encoding", "zalgo"]
 categories = ["encoding", "text-processing"]

--- a/macro/README.md
+++ b/macro/README.md
@@ -17,7 +17,7 @@ on the string "fn square(x: i32) -> i32 {x * x}" we can include the `square`
 function in our program by putting the resulting grapheme cluster inside `zalgo_embed!`:
 
 ```rust
-zalgo_embed!("E͎͓͕͉̞͉͆̀͑́͒̈̀̓̒̉̀̍̀̓̒̀͛̀̊̀͘̚͘͘͝ͅ");
+zalgo_embed!("͎͓͕͉̞͉͆̀͑́͒̈̀̓̒̉̀̍̀̓̒̀͛̀̊̀͘̚͘͘͝ͅ");
 assert_eq!(square(10), 100);
 ```
 

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -12,7 +12,7 @@
 //! by putting the resulting grapheme cluster inside [`zalgo_embed!`]:
 //! ```
 //! # use zalgo_codec_macro::zalgo_embed;
-//! zalgo_embed!("E͎͉͙͉̞͉͙͆̀́̈́̈́̈̀̓̒̌̀̀̓̒̉̀̍̀̓̒̀͛̀̋̀͘̚̚͘͝");
+//! zalgo_embed!("͎͉͙͉̞͉͙͆̀́̈́̈́̈̀̓̒̌̀̀̓̒̉̀̍̀̓̒̀͛̀̋̀͘̚̚͘͝");
 //! assert_eq!(add(10, 20), 30);
 //! ```
 
@@ -40,7 +40,7 @@ use zalgo_codec_common::{zalgo_decode, zalgo_encode};
 /// # use zalgo_codec_macro::zalgo_embed;
 /// // This line expands to the code
 /// // `fn add(x: i32, y: i32) -> i32 {x + y}`
-/// zalgo_embed!("E͎͉͙͉̞͉͙͆̀́̈́̈́̈̀̓̒̌̀̀̓̒̉̀̍̀̓̒̀͛̀̋̀͘̚̚͘͝");
+/// zalgo_embed!("͎͉͙͉̞͉͙͆̀́̈́̈́̈̀̓̒̌̀̀̓̒̉̀̍̀̓̒̀͛̀̋̀͘̚̚͘͝");
 ///
 /// // Now the `add` function is available
 /// assert_eq!(add(10, 20), 30);
@@ -55,7 +55,7 @@ use zalgo_codec_common::{zalgo_decode, zalgo_encode};
 ///
 /// // This macro is expanded to the code
 /// // `x + y`
-/// let z = zalgo_embed!("È͙̋̀͘");
+/// let z = zalgo_embed!("͙̀̋̀͘");
 /// assert_eq!(z, x + y);
 /// ```
 ///
@@ -70,14 +70,14 @@ use zalgo_codec_common::{zalgo_decode, zalgo_encode};
 ///     // let input = std::env::args().collect::<Vec<_>>()[1..].join(" ");
 ///     // let output = zalgo_encode(&input)?;
 ///     // println!("{}", output);
-///     zalgo_embed!("E͔͉͎͕͔̝͓͔͎͖͇͓͌̀͐̀̀̈́́͒̈̉̎̓̚̚̚̚ͅͅ͏̶͔̜̜̞̞̻͌͌̓̓̿̈̉̑̎̎̽̎͊̚̚ͅͅ͏̛͉͎͔̈̂̀̂̉ͯ͌̀ͅ͏͕͔͕͔̝͚͇͐̀̀́͌͏͎̿̓ͅ͏̛͉͎͕͔̟͉͎͔͎̼͎̼͎̈́̈̆͐̉ͯ͐͒͌́̈̂͛̂̌̀͝ͅ͏̛͕͔͕͔͐̉");
+///     zalgo_embed!("͔͉͎͕͔̝͓͔͎͖͇͓͌̀͐̀̀̈́́͒̈̉̎̓̚̚̚̚ͅͅ͏̶͔̜̜̞̞̻͌͌̓̓̿̈̉̑̎̎̽̎͊̚̚ͅͅ͏̛͉͎͔̈̂̀̂̉ͯ͌̀ͅ͏͕͔͕͔̝͚͇͐̀̀́͌͏͎̿̓ͅ͏̛͉͎͕͔̟͉͎͔͎̼͎̼͎̈́̈̆͐̉ͯ͐͒͌́̈̂͛̂̌̀͝ͅ͏̛͕͔͕͔͐̉");
 ///     Ok(())
 /// }
 /// ```
 /// Do the opposite of [`obfstr`](https://docs.rs/obfstr/latest/obfstr/): obfuscate a string while coding and deobfuscate it during compile time
 /// ```
 /// # use zalgo_codec_macro::zalgo_embed;
-/// const SECRET: &str = zalgo_embed!("Ê̤͏͎͔͔͈͉͓͍̇̀͒́̈́̀̀ͅ͏͍́̂");
+/// const SECRET: &str = zalgo_embed!("̤̂͏͎͔͔͈͉͓͍̇̀͒́̈́̀̀ͅ͏͍́̂");
 ///
 /// assert_eq!(SECRET, "Don't read this mom!");
 /// ```
@@ -120,7 +120,7 @@ pub fn zalgo_embed(encoded: TokenStream) -> TokenStream {
 /// ```
 /// # use zalgo_codec_macro::zalgofy;
 /// const ZS: &str = zalgofy!("Zalgo");
-/// assert_eq!(ZS, "É̺͇͌͏");
+/// assert_eq!(ZS, "̺͇́͌͏");
 /// ```
 ///
 /// # Errors


### PR DESCRIPTION
This makes it easier to understand the format, and lets the `new` function be `const`.